### PR TITLE
Pairing dictionary functionality

### DIFF
--- a/gval/utils/loading_datasets.py
+++ b/gval/utils/loading_datasets.py
@@ -5,7 +5,7 @@ Functions to load datasets
 # __all__ = ['*']
 __author__ = "Fernando Aristizabal"
 
-from typing import Union
+from typing import Union, Optional, Tuple, Dict, Any
 import os
 
 import rioxarray as rioxarray
@@ -17,55 +17,89 @@ import rasterio
 
 
 def load_raster_as_xarray(
-    source: Union[
-        str,
-        os.PathLike,
-        rasterio.io.DatasetReader,
-        rasterio.vrt.WarpedVRT,
-        xarray.DataArray,
+    filename: Union[
+        str, os.PathLike, rasterio.io.DatasetReader, rasterio.vrt.WarpedVRT
     ],
-    *args,
-    **kwargs
-) -> xarray.DataArray:
+    parse_coordinates: Optional[bool] = None,
+    chunks: Optional[Union[int, Tuple, Dict]] = None,
+    cache: Optional[bool] = None,
+    lock: Optional[Any] = None,
+    masked: Optional[bool] = False,
+    mask_and_scale: Optional[bool] = False,
+    default_name: Optional[str] = None,
+    band_as_variable: Optional[bool] = False,
+    **open_kwargs,
+) -> Union[xarray.DataArray, xarray.Dataset]:
     """
-    Loads a single raster as xarray DataArray from file path or URL.
-
-    Currently working on extending support for S3.
+    Wraps around :obj:`rioxarray.open_rasterio` providing control over some arguments.
 
     Parameters
     ----------
-    source : str, os.PathLike, rasterio.io.DatasetReader, Rasterio.vrt.WarpedVRT, xarray.DataArray
-        Path to file or opened Rasterio Dataset.
-    *args : args, optional
-        Optional positional arguments to pass to rioxarray.open_rasterio.
-    *kwargs : kwargs, optional
-        Optional keyword arguments to pass to rioxarray.open_rasterio.
+    filename : Union[ str, os.PathLike, rasterio.io.DatasetReader, rasterio.vrt.WarpedVRT ]
+        Path to the file to open. Or already open rasterio dataset
+    parse_coordinates : Optional[bool], default = None
+        Whether to parse the x and y coordinates out of the file's
+        ``transform`` attribute or not. The default is to automatically
+        parse the coordinates only if they are rectilinear (1D).
+        It can be useful to set ``parse_coordinates=False``
+        if your files are very large or if you don't need the coordinates.
+    chunks : Optional[Union[int, Tuple, Dict]], default = None
+        Chunk sizes along each dimension, e.g., ``5``, ``(5, 5)`` or
+        ``{'x': 5, 'y': 5}``. If chunks is provided, it used to load the new
+        DataArray into a dask array. Chunks can also be set to
+        ``True`` or ``"auto"`` to choose sensible chunk sizes according to
+        ``dask.config.get("array.chunk-size")``.
+    cache : Optional[bool], default = None
+        If True, cache data loaded from the underlying datastore in memory as
+        NumPy arrays when accessed to avoid reading from the underlying data-
+        store multiple times. Defaults to True unless you specify the `chunks`
+        argument to use dask, in which case it defaults to False.
+    lock : Optional[Any], default = None
+        If chunks is provided, this argument is used to ensure that only one
+        thread per process is reading from a rasterio file object at a time.
+
+        By default and when a lock instance is provided,
+        a :class:`xarray.backends.CachingFileManager` is used to cache File objects.
+        Since rasterio also caches some data, this will make repeated reads from the
+        same object fast.
+
+        When ``lock=False``, no lock is used, allowing for completely parallel reads
+        from multiple threads or processes. However, a new file handle is opened on
+        each request.
+    masked: Optional[bool], default = False
+        If True, read the mask and set values to NaN. Defaults to False.
+    mask_and_scale: Optional[bool], default = False
+        Lazily scale (using the `scales` and `offsets` from rasterio) and mask.
+        If the _Unsigned attribute is present treat integer arrays as unsigned.
+    default_name : Optional[str], default = None
+        The name of the data array if none exists. Default is None.
+    band_as_variable : Optional[bool], default = False
+        If True, will load bands in a raster to separate variables.
+    open_kwargs : kwargs, default = None
+        Optional keyword arguments to pass into :func:`rasterio.open`.
+
 
     Returns
     -------
-    xarray.DataArray
-        xarray dataarray.
+    Union[:obj:`xarray.DataArray`, :obj:`xarray.Dataset`]
+        Loaded data.
+
+    References
+    ----------
+    .. [1] [Rioxarray `open_rasterio`](https://corteva.github.io/rioxarray/stable/rioxarray.html)
+    .. [2] [`rasterio.open()`](https://rasterio.readthedocs.io/en/stable/api/rasterio.html#rasterio.open)
     """
 
-    # if isinstance(source,(xarray.Dataset,xarray.DataArray)):
+    # TODO: User could pass mask_and_scale and mask which overrides this.
 
-    # existing xarray DataArray
-    if isinstance(source, xarray.DataArray):
-        return source
-
-    # local file path or S3 url
-    elif isinstance(source, (str, os.PathLike)):
-        # TO-DO: support authentication
-        return rioxarray.open_rasterio(source, *args, **kwargs)
-
-    # removed DataSet support for now
-    # List[xarray.DataArray]
-    # elif isinstance(source,list):
-    #    if all( [isinstance(e,xarray.Dataset) for e in source] ):
-    #        return source
-
-    # if neither rasterio dataset, filepath, or url
-    else:
-        raise ValueError(
-            "Source should be a filepath to a raster or xarray Dataset, DataArray or list of Datasets."
-        )
+    return rioxarray.open_rasterio(
+        filename=filename,
+        parse_coordinates=parse_coordinates,
+        cache=cache,
+        lock=lock,
+        default_name=default_name,
+        band_as_variable=band_as_variable,
+        masked=masked,
+        mask_and_scale=mask_and_scale,
+        **open_kwargs,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,8 @@ def benchmark_map(benchmark_map_fp):
 @pytest.fixture(scope="session")
 def agreement_map_fp(comparison):
     """return agreement maps"""
-    _, agreement_map_key = comparison
+    # FIXME: The way this is setup, it only works for test_compute_agreement_xarray(). Need a more correct way of parameterizing these sorts of tests.
+    _, agreement_map_key, _, _ = comparison
     filepath = check_file(
         os.path.join(test_data_dir, f"agreement_map_{agreement_map_key}.tif")
     )

--- a/tests/test_spatial_alignment.py
+++ b/tests/test_spatial_alignment.py
@@ -1,5 +1,5 @@
 """
-Test functionality for gval/prep_comparison/spatial_alignment.py
+Test functionality for gval/homogenize/spatial_alignment.py
 """
 
 # __all__ = ['*']

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,23 +5,34 @@ General utilities for testing sub-package
 # __all__ = ['*']
 __author__ = "Fernando Aristizabal"
 
-from typing import Union
-
-import os
+import numpy as np
 
 
-def _set_aws_environment_variables(AWS_KEYS: Union[os.PathLike, str]) -> None:
+def _assert_pairing_dict_equal(computed_dict: dict, expected_dict: dict) -> None:
     """
-    Sets AWS keys as environment variables for use with testing functionality.
+    Testing function used to test if two pairing dictionaries are equal.
+
+    This is necessary because np.nans can be of float or np.float64 kind which makes operator (==) comparisons false.
 
     Parameters
     ----------
-    AWS_KEYS : Union[os.PathLike, str]
-        File path to AWS keys.
+    computed_dict : dict
+        Pairing dict computed to test.
+    expected_dict : dict
+        Expected pairing dict to compare to.
+
+    Returns
+    -------
+    None
+
+    See also
+    --------
+    :obj:`np.testing.assert_equal`
+
+    Raises
+    ------
+    AssertionError
     """
-    with open(AWS_KEYS, "r") as file_handle:
-        keys = list(file_handle.readlines())[0].rstrip()
-        (
-            os.environ["AWS_ACCESS_KEY_ID"],
-            os.environ["AWS_SECRET_ACCESS_KEY"],
-        ) = keys.split(",")
+
+    np.testing.assert_equal(list(computed_dict.keys()), list(expected_dict.keys()))
+    np.testing.assert_equal(list(computed_dict.values()), list(expected_dict.values()))


### PR DESCRIPTION
Addresses issues #21, #26, and #27.

Partially addresses issues #24 and #25. Users can now use the pairing_dict functionality to work out value mis-alignments and ndv issues.

## Additions

- added functionality allowing for pairing_dict
- added functionality to allow list values with candidates and benchmarks

## Removals

- removed options to pass netcdf related arguments in `rioxarray.open_rasterio` to `load_raster_as_xarray`
- deprecated `_set_aws_environment_variables()`

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards documented [here](https://github.com/NOAA-OWP/gval/blob/main/docs/markdown/05_CONTRIBUTING.MD)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
