### PR TITLE
# Addresses issue #47

### DIFF
--- a/gval/compare.py
+++ b/gval/compare.py
@@ -13,7 +13,7 @@ TODO:
 # __all__ = ['*']
 __author__ = "Fernando Aristizabal"
 
-from typing import Iterable, Optional, Union, Tuple
+from typing import Iterable, Optional, Union, Tuple, Callable
 from numbers import Number
 
 import numpy as np
@@ -273,13 +273,17 @@ def pairing_dict_fn(
 # compare
 
 
-def compute_agreement_xarray(
+def _compute_agreement_map(
     candidate_map: Union[xr.DataArray, xr.Dataset],
     benchmark_map: Union[xr.DataArray, xr.Dataset],
-    comparison_function: Union[nb.np.ufunc.dufunc.DUFunc, np.ufunc, np.vectorize, str],
-    pairing_dict: dict = None,
+    comparison_function: Union[
+        Callable, nb.np.ufunc.dufunc.DUFunc, np.ufunc, np.vectorize, str
+    ],
+    pairing_dict: Optional[dict[Tuple[Number, Number], Number]] = None,
     allow_candidate_values: Optional[Iterable[Number]] = None,
     allow_benchmark_values: Optional[Iterable[Number]] = None,
+    nodata: Optional[Number] = None,
+    encode_nodata: Optional[bool] = False,
 ) -> Union[xr.DataArray, xr.Dataset]:
     """
     Computes agreement map as xarray from candidate and benchmark xarray's.
@@ -290,9 +294,9 @@ def compute_agreement_xarray(
         Candidate map.
     benchmark_map : Union[xr.DataArray, xr.Dataset]
         Benchmark map.
-    comparison_function : Union[nb.np.ufunc.dufunc.DUFunc, np.ufunc, np.vectorize, str]
+    comparison_function : Union[Callable, nb.np.ufunc.dufunc.DUFunc, np.ufunc, np.vectorize, str]
         Comparison function. Created by decorating function with @nb.vectorize() or using np.ufunc(). Use of numba is preferred as it is faster. Strings with registered comparison_functions are also accepted. Possible options include "pairing_dict". If passing "pairing_dict" value, please see the description for the argument for more information on behaviour.
-    pairing_dict: dict[Tuple[Number, Number] : Number], default = None
+    pairing_dict: Optional[dict[Tuple[Number, Number], Number]], default = None
         When "pairing_dict" is used for the comparison_function argument, a pairing dictionary can be passed by user. A pairing dictionary is structured as `{(c, b) : a}` where `(c, b)` is a tuple of the candidate and benchmark value pairing, respectively, and `a` is the value for the agreement array to be used for this pairing.
 
         If None is passed for pairing_dict, the allow_candidate_values and allow_benchmark_values arguments are required. For this case, the pairings in these two iterables will be paired in the order provided and an agreement value will be assigned to each pairing starting with 0 and ending with the number of possible pairings.
@@ -302,31 +306,106 @@ def compute_agreement_xarray(
         List of values in candidate to include in computation of agreement map. Remaining values are excluded. If "pairing_dict" is set selected for comparison_function and pairing_function is None, this argument is necessary to construct the dictionary. Otherwise, this argument is optional and by default this value is set to None and all values are considered.
     allow_benchmark_values : Optional[Iterable[Union[int,float]]], default = None
         List of values in benchmark to include in computation of agreement map. Remaining values are excluded. If "pairing_dict" is set selected for comparison_function and pairing_function is None, this argument is necessary to construct the dictionary. Otherwise, this argument is optional and by default this value is set to None and all values are considered.
+    nodata : Optional[Number], default = None
+        No data value to write to agreement map output. This will use `rxr.rio.write_nodata(nodata)`.
+    encode_nodata : Optional[bool], default = False
+        Encoded no data value to write to agreement map output. A nodata argument must be passed. This will use `rxr.rio.write_nodata(nodata, encode=encode_nodata)`.
 
     Returns
     -------
     Union[xr.DataArray, xr.Dataset]
         Agreement map.
 
+    Raises
+    ------
+    ValueError
+        Must pass a value for 'nodata' argument if setting 'encode_nodata' to True.
+
     References
     ----------
     .. [1] [Creating NumPy universal function](https://numba.readthedocs.io/en/stable/user/vectorize.html)
     .. [2] [NumPy vectorize](https://numpy.org/doc/stable/reference/generated/numpy.vectorize.html)
     .. [3] [NumPy frompyfunc](https://numpy.org/doc/stable/reference/generated/numpy.frompyfunc.html)
+    .. [4] [Rioxarray Manage Information Loss](https://corteva.github.io/rioxarray/stable/getting_started/manage_information_loss.html)
+    .. [5] [Rioxarray NoData Management](https://corteva.github.io/rioxarray/stable/getting_started/nodata_management.html)
     """
 
     """
     TODO:
-    What does dask argument in xr.apply_ufunc do?
-        - If parallelized is selected, several other args should be considered
-        - Including dask_gufunc_kwargs, output_dtypes, output_sizes, and meta.
-    nan management is still not clear across the cases.
-        - masking currently turns everything to nan.
-        - How to handle this??
+    - Understand how these arguments affect the agreement map.
+    - A partial list of some important arguments is included below with either default or presumed values.
+    - These arguments need to be further researched and tested.
+    - `keep_attrs` argument should probably be handled here as to be able to preserve both candidate and benchmark attributes. Possibly consider using a prefix or suffix for attribute keys to denote the source map of the attribute (e.g. {candidate_key: value, benchmark_key: value})
+    - `dask` needs testing with dask arrays.
+    - `dataset_join` needs testing when data variable names in candidate and benchmark differ
+    - `output_dtypes` should be considered to manage dtypes for agreement map
+    - behavior for agreement map should consider how behavior for attributes, variable names, and dtypes in handled within crosstabbing functionality.
+    - read and consider all of the arguments in (xr.apply_ufunc documentation)[https://docs.xarray.dev/en/stable/generated/xarray.apply_ufunc.html]
+    - if the attributes or dtypes of the output agreement map are important, the tests must consider these values by the using the correct `xr.testing.assert_*` function.
+        - Consider switching test to `xr.testing.assert_identical()` to consider names and attributes.
+        - If names are not to be tested, consider using `tests.conftest._assert_pairing_dict_equal()` for attribute testing.
     """
 
-    # sets dask argument for xr.apply_ufunc
-    dask_status = "parallelized"
+    # some input checking to avoid computing ValueErrors
+
+    # nodata is None & encode_nodata is True
+    if nodata is None:
+        if encode_nodata:
+            raise ValueError(
+                "Must pass a value for 'nodata' argument if setting 'encode_nodata' to True."
+            )
+
+    # sets kwargs for xr.apply_ufunc
+    apply_ufunc_kwargs = {
+        "dask": "parallelized",  # how does this work on dask arrays?
+        "keep_attrs": True,  # default, copies attrs from first input
+        "join": "exact",  # default, raise ValueError instead of aligning when indexes to be aligned are not equal
+        "dataset_join": "exact",  # default, data variables on all Dataset objects must match exactly
+        "output_dtypes": None,  # default, Optional list of output dtypes. Only used if dask='parallelized' or vectorize=True.
+    }
+
+    ############################################################################################
+
+    """
+    TODO: xr.apply_ufunc seems to suffer from information loss
+    - The rio accessor is still there.
+    - It appears as if spatial_dims and transforms are being preserved.
+    - Currently, CRS is identified as lost and is being reset.
+    - NoData and encoded NoData are also not being managed for agreement map.
+        - [See this for more information](https://corteva.github.io/rioxarray/stable/getting_started/nodata_management.html).
+    - attrs are not being copied from both candidate and benchmark, just candidate.
+    - How about encodings?
+    - Dtypes?
+    - Anything else?
+    - For more information, please see pages on [information loss](https://corteva.github.io/rioxarray/stable/getting_started/manage_information_loss.html) and [`xr.apply_ufunc`](https://docs.xarray.dev/en/stable/generated/xarray.apply_ufunc.html).
+    - These changes need to be researched and tested properly.
+        - Consider switching test to `xr.testing.assert_identical()` to consider names and attributes.
+        - If names are not to be tested, consider using `tests.conftest._assert_pairing_dict_equal()` for attribute testing.
+    """
+
+    def _manage_information_loss(agreement_map, crs, nodata, encode_nodata):
+        """
+        Manages the information loss due to `xr.apply_ufunc`
+
+        This encapsulated function is to manage information loss that can't be managed with apply_ufunc_kwargs.
+        """
+
+        # sets CRS that is lost with `xr.apply_ufunc`
+        agreement_map.rio.set_crs(candidate_map.rio.crs, inplace=True)
+
+        # setting agreement map nodata and encoded nodata
+        if nodata is not None:
+            # this masks the desired nodata value within agreement
+            if encode_nodata:
+                # TODO: While currently using float, more management and testing for various input dtype combinations vs output dtypes is required.
+                agreement_map = agreement_map.astype(float).where(
+                    agreement_map != nodata
+                )
+
+            # writes no data and encoded no data if set
+            agreement_map.rio.write_nodata(nodata, encoded=encode_nodata, inplace=True)
+
+        return agreement_map
 
     ############################################################################################
     # Masking out values not in allowed lists
@@ -357,23 +436,30 @@ def compute_agreement_xarray(
             )
 
         """
-        FIXME:
+        NOTE:
         When pairing_dict_fn is decorated with @nb.vectorize(nopython=True). A typing error occurs.
             - Noticed that np.vectorize seems to perform well so removing numba for pairing_dict
             - Line of code to use if using numba:
                 - pairing_dict = _convert_dict_to_numba(pairing_dict)
         """
 
-        # this return is for the pairing_dict case
-        return xr.apply_ufunc(
+        # this is for the pairing_dict case
+        agreement_map = xr.apply_ufunc(
             pairing_dict_fn,
             candidate_map,
             benchmark_map,
-            [
-                pairing_dict
-            ],  # encapsulating this in a list is necessary for vectorization
-            dask=dask_status,
+            [pairing_dict],
+            **apply_ufunc_kwargs,
         )
+
+        agreement_map = _manage_information_loss(
+            agreement_map=agreement_map,
+            crs=candidate_map.rio.crs,
+            nodata=nodata,
+            encode_nodata=encode_nodata,
+        )
+
+        return agreement_map
 
     ###########################################################################################
     # for cases when pairing dictionaries are not being used at all.
@@ -384,9 +470,19 @@ def compute_agreement_xarray(
     """
 
     # use xarray apply ufunc to apply comparison to candidate and benchmark xarray's
-    return xr.apply_ufunc(
-        comparison_function, candidate_map, benchmark_map, dask=dask_status
+    # NOTE: Default behavior loses CRS and uses nodata from first argument (candidate_map)
+    agreement_map = xr.apply_ufunc(
+        comparison_function, candidate_map, benchmark_map, **apply_ufunc_kwargs
     )
+
+    agreement_map = _manage_information_loss(
+        agreement_map=agreement_map,
+        crs=candidate_map.rio.crs,
+        nodata=nodata,
+        encode_nodata=encode_nodata,
+    )
+
+    return agreement_map
 
 
 def _convert_crosstab_to_contigency_table(crosstab_df: pd.DataFrame) -> pd.DataFrame:
@@ -585,7 +681,9 @@ def _crosstab_DataArrays(
     elif len(candidate_map.shape) == len(benchmark_map.shape) == 2:
         crosstab_func = _crosstab_2d_DataArrays
     else:
-        ValueError("Candidate and benchmark must be both 2 or 3 dimensional only.")
+        raise ValueError(
+            "Candidate and benchmark must be both 2 or 3 dimensional only."
+        )
 
     return crosstab_func(
         candidate_map=candidate_map,

--- a/tests/cases_compare.py
+++ b/tests/cases_compare.py
@@ -370,8 +370,29 @@ def case_crosstab_3d_DataArrays(candidate_map, benchmark_map, expected_df):
     "candidate_map, benchmark_map, expected_df",
     crosstab_2d_DataArrayss + crosstab_3d_DataArrayss,
 )
-def case_crosstab_DataArrays(candidate_map, benchmark_map, expected_df):
+def case_crosstab_DataArrays_success(candidate_map, benchmark_map, expected_df):
     return candidate_map, benchmark_map, expected_df
+
+
+crosstab_DataArrays_fails = [
+    (
+        _load_xarray(
+            "candidate_categorical_multiband_aligned_0.tif",
+            masked=True,
+            mask_and_scale=True,
+        ).expand_dims({"dummy_dim": 1}),
+        _load_xarray(
+            "benchmark_categorical_multiband_aligned_0.tif",
+            masked=True,
+            mask_and_scale=True,
+        ).expand_dims({"dummy_dim": 1}),
+    )
+]
+
+
+@parametrize("candidate_map, benchmark_map", crosstab_DataArrays_fails)
+def case_crosstab_DataArrays_fail(candidate_map, benchmark_map):
+    return candidate_map, benchmark_map
 
 
 _crosstab_Datasets = crosstab_3d_DataArrayss
@@ -417,77 +438,124 @@ def case_crosstab_Datasets(candidate_map, benchmark_map, expected_df):
     return candidate_map, benchmark_map, expected_df
 
 
-compute_agreement_xarrays = [
+compute_agreement_maps_success = [
     (
         "candidate_map_0_aligned_to_candidate_map_0.tif",
         "benchmark_map_0_aligned_to_candidate_map_0.tif",
-        "agreement_map_00_szudzik_aligned_to_candidate_map_0.tif",
+        _load_xarray("agreement_map_00_szudzik_aligned_to_candidate_map_0.tif"),
         szudzik_pair_signed,
         None,
         None,
+        None,
+        None,
     ),
     (
         "candidate_map_0_aligned_to_candidate_map_0.tif",
         "benchmark_map_0_aligned_to_candidate_map_0.tif",
-        "agreement_map_00_cantor_aligned_to_candidate_map_0.tif",
+        _load_xarray("agreement_map_00_cantor_aligned_to_candidate_map_0.tif"),
         cantor_pair_signed,
         None,
         None,
+        None,
+        None,
     ),
     (
         "candidate_map_0_aligned_to_candidate_map_0.tif",
         "benchmark_map_0_aligned_to_candidate_map_0.tif",
-        "agreement_map_00_pairing_aligned_to_candidate_map_0.tif",
+        _load_xarray("agreement_map_00_pairing_aligned_to_candidate_map_0.tif"),
         "pairing_dict",
         [-9999, 1, 2],
         [0, 2],
+        None,
+        None,
+    ),
+    (
+        "candidate_map_0_aligned_to_candidate_map_0.tif",
+        "benchmark_map_0_aligned_to_candidate_map_0.tif",
+        _load_xarray("agreement_map_00_szudzik_aligned_to_candidate_map_0_nodata.tif"),
+        szudzik_pair_signed,
+        None,
+        None,
+        399900006,
+        None,
+    ),
+    (
+        "candidate_map_0_aligned_to_candidate_map_0.tif",
+        "benchmark_map_0_aligned_to_candidate_map_0.tif",
+        _load_xarray(
+            "agreement_map_00_szudzik_aligned_to_candidate_map_0_nodata.tif",
+            masked=True,
+            mask_and_scale=True,
+        ),
+        szudzik_pair_signed,
+        None,
+        None,
+        399900006,
+        True,
     ),
 ]
 
 
 @parametrize(
-    "candidate_map, benchmark_map, agreement_map, comparison_function, allow_candidate_values, allow_benchmark_values",
-    compute_agreement_xarrays,
+    "candidate_map, benchmark_map, agreement_map, comparison_function, allow_candidate_values, allow_benchmark_values, nodata, encode_nodata",
+    compute_agreement_maps_success,
 )
-def case_compute_agreement_xarray(
+def case_compute_agreement_map_success(
     candidate_map,
     benchmark_map,
     agreement_map,
     comparison_function,
     allow_candidate_values,
     allow_benchmark_values,
+    nodata,
+    encode_nodata,
 ):
     return (
         _load_xarray(candidate_map),
         _load_xarray(benchmark_map),
-        _load_xarray(agreement_map),
+        agreement_map,
         comparison_function,
         allow_candidate_values,
         allow_benchmark_values,
+        nodata,
+        encode_nodata,
     )
 
 
-compute_xarray_fail_case = [
+compute_agreement_maps_fail = [
     (
         "candidate_map_0_aligned_to_candidate_map_0.tif",
         "benchmark_map_0_aligned_to_candidate_map_0.tif",
         "pairing_dict",
         None,
         None,
-    )
+        None,
+        None,
+    ),
+    (
+        "candidate_map_0_aligned_to_candidate_map_0.tif",
+        "benchmark_map_0_aligned_to_candidate_map_0.tif",
+        szudzik_pair_signed,
+        None,
+        None,
+        None,
+        True,
+    ),
 ]
 
 
 @parametrize(
-    "candidate_map, benchmark_map, comparison_function, allow_candidate_values, allow_benchmark_values",
-    compute_xarray_fail_case,
+    "candidate_map, benchmark_map, comparison_function, allow_candidate_values, allow_benchmark_values, nodata, encode_nodata",
+    compute_agreement_maps_fail,
 )
-def case_compute_agreement_xarray_fail(
+def case_compute_agreement_map_fail(
     candidate_map,
     benchmark_map,
     comparison_function,
     allow_candidate_values,
     allow_benchmark_values,
+    nodata,
+    encode_nodata,
 ):
     return (
         _load_xarray(candidate_map),
@@ -495,4 +563,6 @@ def case_compute_agreement_xarray_fail(
         comparison_function,
         allow_candidate_values,
         allow_benchmark_values,
+        nodata,
+        encode_nodata,
     )

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -20,7 +20,7 @@ from gval.compare import (
     szudzik_pair_signed,
     _make_pairing_dict,
     pairing_dict_fn,
-    compute_agreement_xarray,
+    _compute_agreement_map,
     _convert_crosstab_to_contigency_table,
     _crosstab_2d_DataArrays,
     _crosstab_3d_DataArrays,
@@ -141,12 +141,19 @@ def test_crosstab_3d_DataArrays(candidate_map, benchmark_map, expected_df):
 
 
 @parametrize_with_cases(
-    "candidate_map, benchmark_map, expected_df", glob="crosstab_DataArrays"
+    "candidate_map, benchmark_map, expected_df", glob="crosstab_DataArrays_success"
 )
-def test_crosstab_DataArrays(candidate_map, benchmark_map, expected_df):
+def test_crosstab_DataArrays_success(candidate_map, benchmark_map, expected_df):
     """Test crosstabbing candidate and benchmark DataArrays"""
     crosstab_df = _crosstab_DataArrays(candidate_map, benchmark_map)
     pd.testing.assert_frame_equal(crosstab_df, expected_df, check_dtype=False)
+
+
+@parametrize_with_cases("candidate_map, benchmark_map", glob="crosstab_DataArrays_fail")
+def test_crosstab_DataArrays_fail(candidate_map, benchmark_map):
+    """Test crosstabbing candidate and benchmark DataArrays"""
+    with raises(ValueError):
+        _crosstab_DataArrays(candidate_map, benchmark_map)
 
 
 @parametrize_with_cases(
@@ -160,25 +167,29 @@ def test_crosstab_Datasets(candidate_map, benchmark_map, expected_df):
 
 
 @parametrize_with_cases(
-    "candidate_map, benchmark_map, agreement_map, comparison_function, allow_candidate_values, allow_benchmark_values",
-    glob="compute_agreement_xarray",
+    "candidate_map, benchmark_map, agreement_map, comparison_function, allow_candidate_values, allow_benchmark_values, nodata, encode_nodata",
+    glob="compute_agreement_map_success",
 )
-def test_compute_agreement_xarray(
+def test_compute_agreement_map_success(
     candidate_map,
     benchmark_map,
     agreement_map,
     comparison_function,
     allow_candidate_values,
     allow_benchmark_values,
+    nodata,
+    encode_nodata,
 ):
     """Tests computing of agreement xarray from two xarrays"""
 
-    agreement_map_computed = compute_agreement_xarray(
+    agreement_map_computed = _compute_agreement_map(
         candidate_map,
         benchmark_map,
         comparison_function,
         allow_candidate_values=allow_candidate_values,
         allow_benchmark_values=allow_benchmark_values,
+        nodata=nodata,
+        encode_nodata=encode_nodata,
     )
 
     # Use xr.testing.assert_identical() if names and attributes need to be compared too
@@ -186,23 +197,27 @@ def test_compute_agreement_xarray(
 
 
 @parametrize_with_cases(
-    "candidate_map, benchmark_map, comparison_function, allow_candidate_values, allow_benchmark_values",
-    glob="compute_agreement_xarray_fail",
+    "candidate_map, benchmark_map, comparison_function, allow_candidate_values, allow_benchmark_values, nodata, encode_nodata",
+    glob="compute_agreement_map_fail",
 )
-def test_compute_agreement_xarray_fail(
+def test_compute_agreement_map_fail(
     candidate_map,
     benchmark_map,
     comparison_function,
     allow_candidate_values,
     allow_benchmark_values,
+    nodata,
+    encode_nodata,
 ):
     """Tests fail computing of agreement xarray from two xarrays"""
 
     with raises(ValueError):
-        _ = compute_agreement_xarray(
+        _ = _compute_agreement_map(
             candidate_map,
             benchmark_map,
             comparison_function,
             allow_candidate_values=allow_candidate_values,
             allow_benchmark_values=allow_benchmark_values,
+            nodata=nodata,
+            encode_nodata=encode_nodata,
         )


### PR DESCRIPTION
This commit deals with problems associated with the agreement map output within `compute_agreement_xarray()`.

It closes issue #47.

CRSs and NDVs are not properly managed for agreement maps.

- changed `compute_agreement_xarray()` to private function and renamed to `_compute_agreement_map()` to maintain consistency.
- added `apply_ufunc_kwargs` to manage potential arguments to `xr.apply_ufunc`
- added notes on `apply_ufunc_kwargs` to motivate better understanding of these arguments and future feature development.
- added two arguments `nodata` and `encoded_nodata` to `_compute_agreement_map()` to set nodata attributes within agreement map output.
- added `_manage_information_loss()` encapsulated withing `_compute_agreement_map()` to manage some of the information loss from `xr.apply_ufunc()`. - this applies CRS to agreement map - also designates `nodata` and `encoded_nodata` attributes for agreement maps.
- Current argument values within `apply_ufunc_kwargs` changes some behavior of `_compute_agreement_xarray`.
    - TODO: Inspect these key value arguments to investigate effects on agreement map output.
    - moved test coverage to 100% by testing possible failure case in `_crosstab_DataArrays()`
