### PR TITLE
Agreement map vector

### DIFF
--- a/src/gval/accessors/gval_xarray.py
+++ b/src/gval/accessors/gval_xarray.py
@@ -33,7 +33,7 @@ class GVALXarray:
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
         self.data_type = type(xarray_obj)
-        self.benchmark_format = "raster"
+        self.agreement_map_format = "raster"
 
     def check_same_type(self, benchmark_map: Union[xr.Dataset, xr.DataArray]):
         """
@@ -137,7 +137,7 @@ class GVALXarray:
                 benchmark_map=benchmark_map,
                 rasterize_attributes=rasterize_attributes,
             )
-            self.benchmark_format = "vector"
+            self.agreement_map_format = "vector"
 
         self.check_same_type(benchmark_map)
 
@@ -163,7 +163,7 @@ class GVALXarray:
             encode_nodata=encode_nodata,
         )
 
-        if self.benchmark_format == "vector":
+        if self.agreement_map_format == "vector":
             agreement_map = _vectorize_data(agreement_map)
 
         crosstab_df = candidate.gval.compute_crosstab(
@@ -226,7 +226,7 @@ class GVALXarray:
                 benchmark_map=benchmark_map,
                 rasterize_attributes=rasterize_attributes,
             )
-            self.benchmark_format = "vector"
+            self.agreement_map_format = "vector"
 
         self.check_same_type(benchmark_map)
 
@@ -297,7 +297,7 @@ class GVALXarray:
             encode_nodata=encode_nodata,
         )
 
-        if self.benchmark_format == "vector":
+        if self.agreement_map_format == "vector":
             agreement_map = _vectorize_data(agreement_map)
 
         return agreement_map

--- a/src/gval/accessors/gval_xarray.py
+++ b/src/gval/accessors/gval_xarray.py
@@ -10,6 +10,7 @@ import geopandas as gpd
 
 from gval.homogenize.spatial_alignment import _spatial_alignment
 from gval.homogenize.rasterize import _rasterize_data
+from gval.homogenize.vectorize import _vectorize_data
 from gval.homogenize.numeric_alignment import _align_numeric_data_type
 from gval import Comparison
 from gval.comparison.tabulation import _crosstab_Datasets, _crosstab_DataArrays
@@ -32,6 +33,7 @@ class GVALXarray:
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
         self.data_type = type(xarray_obj)
+        self.benchmark_format = "raster"
 
     def check_same_type(self, benchmark_map: Union[xr.Dataset, xr.DataArray]):
         """
@@ -135,6 +137,7 @@ class GVALXarray:
                 benchmark_map=benchmark_map,
                 rasterize_attributes=rasterize_attributes,
             )
+            self.benchmark_format = "vector"
 
         self.check_same_type(benchmark_map)
 
@@ -159,6 +162,9 @@ class GVALXarray:
             nodata=nodata,
             encode_nodata=encode_nodata,
         )
+
+        if self.benchmark_format == "vector":
+            agreement_map = _vectorize_data(agreement_map)
 
         crosstab_df = candidate.gval.compute_crosstab(
             benchmark_map=benchmark,
@@ -220,6 +226,7 @@ class GVALXarray:
                 benchmark_map=benchmark_map,
                 rasterize_attributes=rasterize_attributes,
             )
+            self.benchmark_format = "vector"
 
         self.check_same_type(benchmark_map)
 
@@ -238,7 +245,7 @@ class GVALXarray:
 
     def compute_agreement_map(
         self,
-        benchmark_map: xr.Dataset,
+        benchmark_map: Union[xr.Dataset, xr.DataArray],
         comparison_function: Union[
             Callable, nb.np.ufunc.dufunc.DUFunc, np.ufunc, np.vectorize, str
         ] = "szudzik",
@@ -279,7 +286,7 @@ class GVALXarray:
         """
         self.check_same_type(benchmark_map)
 
-        return Comparison.process_agreement_map(
+        agreement_map = Comparison.process_agreement_map(
             candidate_map=self._obj,
             benchmark_map=benchmark_map,
             comparison_function=comparison_function,
@@ -289,6 +296,11 @@ class GVALXarray:
             nodata=nodata,
             encode_nodata=encode_nodata,
         )
+
+        if self.benchmark_format == "vector":
+            agreement_map = _vectorize_data(agreement_map)
+
+        return agreement_map
 
     def compute_crosstab(
         self,

--- a/src/gval/homogenize/vectorize.py
+++ b/src/gval/homogenize/vectorize.py
@@ -1,0 +1,90 @@
+from typing import Union
+
+import geopandas as gpd
+import numpy as np
+from shapely.geometry import shape
+from rasterio.features import shapes
+import xarray as xr
+
+
+def _vectorize_data(
+    raster_data: Union[xr.Dataset, xr.DataArray],
+) -> gpd.GeoDataFrame:
+    """
+
+    Parameters
+    ----------
+    raster_data: Union[xr.Dataset, xr.DataArray]
+        Raster map to convert to vectorized map
+
+    Returns
+    -------
+    gpd.GeoDataFrame
+        Vectorized data
+
+    """
+
+    # Allowed numerical datatypes in vectorize operation
+    dtypes = [np.int16, np.int32, np.uint8, np.uint16, np.float32]
+
+    def get_dtype(dtype):
+        """
+        Conform datatype to alloable vectorize dtype
+
+        Parameters
+        ----------
+        dtype : type
+            Numerical datatype of raster data
+
+        Returns
+        -------
+        type
+            Type to use for vectorizing
+        """
+
+        if dtype not in dtypes:
+            if np.issubdtype(dtype, np.integer):
+                dtype = np.int32
+            else:
+                dtype = np.float32
+
+        return dtype
+
+    # Get bands, nodata, and dtype for data array or every var from a dataset
+    if isinstance(raster_data, xr.DataArray):
+        if len(raster_data.shape) > 2:
+            iter_bands = [
+                f"band_{coord.values}" for coord in raster_data.coords["band"]
+            ]
+            indices = range(raster_data.shape[0])
+        else:
+            iter_bands, indices = ["band_1"], [slice(0, raster_data.shape[0])]
+        nodata_vals = [raster_data.rio.nodata] * len(iter_bands)
+        dtypes = [get_dtype(raster_data.dtype)] * len(iter_bands)
+
+    else:
+        iter_bands = indices = [d_var for d_var in raster_data.data_vars]
+        nodata_vals = [raster_data[d_var].rio.nodata for d_var in raster_data.data_vars]
+        dtypes = [
+            get_dtype(raster_data[d_var].dtype) for d_var in raster_data.data_vars
+        ]
+
+    bands, values, geometry = [], [], []
+
+    # Iterate over values and vectorize shapes
+    for idx, band, nodata, dtype in zip(indices, iter_bands, nodata_vals, dtypes):
+        shps = shapes(
+            raster_data[idx].astype(np.float32),
+            transform=raster_data[idx].rio.transform(),
+        )
+
+        for shp in shps:
+            if shp[1] != nodata and not np.isnan(shp[1]):
+                values.append(shp[1])
+                geometry.append(shape(shp[0]))
+                bands.append(band.split("_")[-1])
+
+    gdf_vec = gpd.GeoDataFrame({"band": bands, "values": values, "geometry": geometry})
+    gdf_vec.crs = raster_data[idx].rio.crs
+
+    return gdf_vec

--- a/tests/cases_accessors.py
+++ b/tests/cases_accessors.py
@@ -100,10 +100,19 @@ def case_data_array_accessor_homogenize(
 
 
 @parametrize(
-    "candidate_map, benchmark_map", list(zip(candidate_maps[0:1], benchmark_maps[0:1]))
+    "candidate_map, benchmark_map, vectorized",
+    list(
+        zip(
+            [candidate_maps[0], candidate_maps[0]],
+            [benchmark_maps[0], benchmark_maps[0]],
+            [False, True],
+        )
+    ),
 )
-def case_data_array_accessor_compute_agreement(candidate_map, benchmark_map):
-    return candidate_map, benchmark_map
+def case_data_array_accessor_compute_agreement(
+    candidate_map, benchmark_map, vectorized
+):
+    return candidate_map, benchmark_map, vectorized
 
 
 @parametrize(

--- a/tests/cases_homogenize.py
+++ b/tests/cases_homogenize.py
@@ -280,6 +280,31 @@ def case_rasterize_vector_fail(candidate_map, benchmark_map, rasterize_attribute
     return candidate_map, benchmark_map, rasterize_attributes
 
 
+# @parametrize(
+#     "candidate_map, benchmark_map, rasterize_attributes, expected",
+#     list(
+#         zip(candidate_map_rasters, benchmark_map_vectors, rasterize_attrs, expected_res)
+#     ),
+# )
+# def case_vectorize_raster_success(
+#     candidate_map, benchmark_map, rasterize_attributes, expected
+# ):
+#     return candidate_map, benchmark_map, rasterize_attributes, expected
+#
+#
+# rasterize_attrs_fail = [["fail"], ["hwmTypeName"]]
+#
+#
+# @parametrize(
+#     "candidate_map, benchmark_map, rasterize_attributes",
+#     list(
+#         zip(candidate_map_rasters[:2], benchmark_map_vectors[:2], rasterize_attrs_fail)
+#     ),
+# )
+# def case_rasterize_vector_fail(candidate_map, benchmark_map, rasterize_attributes):
+#     return candidate_map, benchmark_map, rasterize_attributes
+
+
 expected_type = [np.int32, np.float32, float, float]
 
 

--- a/tests/cases_homogenize.py
+++ b/tests/cases_homogenize.py
@@ -255,6 +255,23 @@ expected_res = [
 ]
 
 
+vectorize_rasters = [
+    _load_xarray("candidate_map_0_accessor.tif", mask_and_scale=True),
+    _load_xarray("candidate_map_0_accessor.tif").astype(np.int64),
+    _load_xarray("candidate_map_0_accessor.tif", mask_and_scale=True).sel(
+        band=1, drop=True
+    ),
+    _load_xarray(
+        "candidate_map_0_accessor.tif", mask_and_scale=True, band_as_variable=True
+    ),
+    _load_xarray("polygons.tif", mask_and_scale=True),
+]
+expected_vectors = [
+    _load_gpkg("expected_df.gpkg"),
+    _load_gpkg("expected_polygons_df.gpkg"),
+]
+
+
 @parametrize(
     "candidate_map, benchmark_map, rasterize_attributes, expected",
     list(
@@ -280,29 +297,31 @@ def case_rasterize_vector_fail(candidate_map, benchmark_map, rasterize_attribute
     return candidate_map, benchmark_map, rasterize_attributes
 
 
-# @parametrize(
-#     "candidate_map, benchmark_map, rasterize_attributes, expected",
-#     list(
-#         zip(candidate_map_rasters, benchmark_map_vectors, rasterize_attrs, expected_res)
-#     ),
-# )
-# def case_vectorize_raster_success(
-#     candidate_map, benchmark_map, rasterize_attributes, expected
-# ):
-#     return candidate_map, benchmark_map, rasterize_attributes, expected
-#
-#
-# rasterize_attrs_fail = [["fail"], ["hwmTypeName"]]
-#
-#
-# @parametrize(
-#     "candidate_map, benchmark_map, rasterize_attributes",
-#     list(
-#         zip(candidate_map_rasters[:2], benchmark_map_vectors[:2], rasterize_attrs_fail)
-#     ),
-# )
-# def case_rasterize_vector_fail(candidate_map, benchmark_map, rasterize_attributes):
-#     return candidate_map, benchmark_map, rasterize_attributes
+@parametrize(
+    "raster_map, expected",
+    list(
+        zip(
+            vectorize_rasters,
+            [
+                expected_vectors[0],
+                expected_vectors[0],
+                expected_vectors[0],
+                expected_vectors[0],
+                expected_vectors[1],
+            ],
+        )
+    ),
+)
+def case_vectorize_raster_success(raster_map, expected):
+    return raster_map, expected
+
+
+@parametrize(
+    "raster_map",
+    list(zip(expected_vectors)),
+)
+def case_vectorize_raster_fail(raster_map):
+    return raster_map
 
 
 expected_type = [np.int32, np.float32, float, float]

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -23,7 +23,10 @@ def test_data_array_accessor_success(
         rasterize_attributes=rasterize_attributes,
     )
 
-    assert isinstance(data[0], xr.DataArray)
+    if rasterize_attributes is None:
+        assert isinstance(data[0], xr.DataArray)
+    else:
+        assert isinstance(data[0], DataFrame)
     assert isinstance(data[1], DataFrame)
     assert isinstance(data[2], DataFrame)
 
@@ -59,15 +62,25 @@ def test_data_array_accessor_homogenize(
 
 
 @parametrize_with_cases(
-    "candidate_map, benchmark_map", glob="data_array_accessor_compute_agreement"
+    "candidate_map, benchmark_map, vectorized",
+    glob="data_array_accessor_compute_agreement",
 )
-def test_data_array_accessor_compute_agreement_success(candidate_map, benchmark_map):
+def test_data_array_accessor_compute_agreement_success(
+    candidate_map, benchmark_map, vectorized
+):
     aligned_cand, aligned_bench = candidate_map.gval.homogenize(
         benchmark_map=benchmark_map
     )
+
+    if vectorized:
+        aligned_cand.gval.benchmark_format = "vector"
+
     data = aligned_cand.gval.compute_agreement_map(benchmark_map=aligned_bench)
 
-    assert isinstance(data, xr.DataArray)
+    if vectorized:
+        assert isinstance(data, DataFrame)
+    else:
+        assert isinstance(data, xr.DataArray)
 
 
 @parametrize_with_cases(
@@ -120,7 +133,10 @@ def test_data_set_accessor_success(
         rasterize_attributes=rasterize_attributes,
     )
 
-    assert isinstance(data[0], xr.Dataset)
+    if rasterize_attributes is None:
+        assert isinstance(data[0], xr.Dataset)
+    else:
+        assert isinstance(data[0], DataFrame)
     assert isinstance(data[1], DataFrame)
     assert isinstance(data[2], DataFrame)
 

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -73,7 +73,7 @@ def test_data_array_accessor_compute_agreement_success(
     )
 
     if vectorized:
-        aligned_cand.gval.benchmark_format = "vector"
+        aligned_cand.gval.agreement_map_format = "vector"
 
     data = aligned_cand.gval.compute_agreement_map(benchmark_map=aligned_bench)
 

--- a/tests/test_homogenize.py
+++ b/tests/test_homogenize.py
@@ -9,6 +9,7 @@ from pytest import raises
 from pytest_cases import parametrize_with_cases
 import xarray as xr
 import numpy as np
+import geopandas as gpd
 
 from gval.homogenize.spatial_alignment import (
     _matching_crs,
@@ -19,6 +20,7 @@ from gval.homogenize.spatial_alignment import (
 )
 from gval.homogenize.numeric_alignment import _align_numeric_data_type
 from gval.homogenize.rasterize import _rasterize_data
+from gval.homogenize.vectorize import _vectorize_data
 from gval.utils.exceptions import RasterMisalignment, RastersDontIntersect
 
 
@@ -177,6 +179,30 @@ def test_rasterize_vector_fail(candidate_map, benchmark_map, rasterize_attribute
             benchmark_map=benchmark_map,
             rasterize_attributes=rasterize_attributes,
         )
+
+
+@parametrize_with_cases(
+    "raster_map, expected",
+    glob="vectorize_raster_success",
+)
+def test_vectorize_raster_success(raster_map, expected):
+    """Test vectorize raster success"""
+
+    vector_df = _vectorize_data(raster_data=raster_map)
+
+    assert isinstance(vector_df, gpd.GeoDataFrame)
+    assert vector_df.equals(expected)
+
+
+@parametrize_with_cases(
+    "raster_map",
+    glob="vectorize_raster_fail",
+)
+def test_vectorize_raster_fail(raster_map):
+    """Tests vectorize raster fail"""
+
+    with raises(AttributeError):
+        _ = _vectorize_data(raster_map)
 
 
 @parametrize_with_cases(


### PR DESCRIPTION
Pull request addressing #117 

## Additions

- homogenize/vectorize.py - Provides the ability to vectorize raster datasets

## Removals

-

## Changes

- accessors/gval_xarray.py - Provide support for tracking vector benchmark data and returning vector agreement maps
- cases_accesors.py - Add cases to test vector compute agreement map procedure
- test_acessors.py - Add testing for vector compute agreemnet map procedure
- cases_homogenize.py - Add cases to test vectorize operation
- test_homogenize.py - Add tests for vectorize operation
