### PR TITLE
Continuous Compare Implementation, Closes #110

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ notebooks/metric_file.csv
 #IDE
 .idea
 .idea.*
+
+# docs
+docs/sphinx/_build/

--- a/src/gval/comparison/agreement.py
+++ b/src/gval/comparison/agreement.py
@@ -120,23 +120,6 @@ def _compute_agreement_map(
 
     ############################################################################################
 
-    """
-    TODO: xr.apply_ufunc seems to suffer from information loss
-    - The rio accessor is still there.
-    - It appears as if spatial_dims and transforms are being preserved.
-    - Currently, CRS is identified as lost and is being reset.
-    - NoData and encoded NoData are also not being managed for agreement map.
-        - [See this for more information](https://corteva.github.io/rioxarray/stable/getting_started/nodata_management.html).
-    - attrs are not being copied from both candidate and benchmark, just candidate.
-    - How about encodings?
-    - Dtypes?
-    - Anything else?
-    - For more information, please see pages on [information loss](https://corteva.github.io/rioxarray/stable/getting_started/manage_information_loss.html) and [`xr.apply_ufunc`](https://docs.xarray.dev/en/stable/generated/xarray.apply_ufunc.html).
-    - These changes need to be researched and tested properly.
-        - Consider switching test to `xr.testing.assert_identical()` to consider names and attributes.
-        - If names are not to be tested, consider using `tests.conftest._assert_pairing_dict_equal()` for attribute testing.
-    """
-
     def _manage_information_loss(agreement_map, crs, nodata, encode_nodata, dtype):
         """
         Manages the information loss due to `xr.apply_ufunc`

--- a/src/gval/comparison/compute_comparison.py
+++ b/src/gval/comparison/compute_comparison.py
@@ -7,10 +7,7 @@ from numbers import Number
 import numba as nb
 import xarray as xr
 
-from gval.comparison.pairing_functions import (
-    cantor_pair_signed,
-    szudzik_pair_signed,
-)
+from gval.comparison.pairing_functions import cantor_pair_signed, szudzik_pair_signed
 from gval.comparison.agreement import _compute_agreement_map
 
 

--- a/src/gval/comparison/compute_continuous_metrics.py
+++ b/src/gval/comparison/compute_continuous_metrics.py
@@ -1,0 +1,126 @@
+"""
+Computes continuous value metrics given an agreement map.
+"""
+
+# __all__ = ['*']
+__author__ = "Fernando Aristizabal"
+
+from typing import Iterable, Union
+
+import pandera as pa
+import pandas as pd
+from pandera.typing import DataFrame
+import xarray as xr
+
+from gval.utils.schemas import Metrics_df
+
+from gval.statistics.continuous_stat_funcs import (
+    mean_absolute_error,
+    mean_squared_error,
+    root_mean_squared_error,
+    mean_percentage_error,
+    mean_absolute_percentage_error,
+    coefficient_of_determination,
+    mean_normalized_mean_absolute_error,
+    range_normalized_mean_absolute_error,
+    mean_normalized_root_mean_squared_error,
+    range_normalized_root_mean_squared_error,
+)
+
+
+@pa.check_types
+def _compute_continuous_metrics(
+    agreement_map: Union[xr.DataArray, xr.Dataset] = None,
+    candidate_map: Union[xr.DataArray, xr.Dataset] = None,
+    benchmark_map: Union[xr.DataArray, xr.Dataset] = None,
+    metrics: Union[str, Iterable[str]] = "all",
+) -> DataFrame[Metrics_df]:
+    """
+    Computes categorical metrics from a crosstab df.
+
+    Parameters
+    ----------
+    agreement_map : Union[xr.DataArray, xr.Dataset], default = None
+        Agreement map, error based (candidate - benchmark).
+    candidate_map : Union[xr.DataArray, xr.Dataset], default = None
+        Candidate map.
+    benchmark_map : Union[xr.DataArray, xr.Dataset], default = None
+        Benchmark map.
+    metrics : Union[str, Iterable[str]], default = "all"
+        String or list of strings representing metrics to compute.
+
+    Returns
+    -------
+    DataFrame[Metrics_df]
+        Metrics DF with computed metrics per sample.
+
+    Raises
+    ------
+    ValueError
+        If metrics is not a string or list of strings.
+
+    References
+    ----------
+    .. [1] [7th International Verification Methods Workshop](https://www.cawcr.gov.au/projects/verification/)
+    .. [2] [3.3. Metrics and scoring: quantifying the quality of predictions](https://scikit-learn.org/stable/modules/model_evaluation.html)
+    """
+
+    # compute error based metrics such as MAE, MSE, RMSE, etc. from agreement map and produce metrics_df
+
+    all_metric_funcs = [
+        mean_absolute_error,
+        mean_squared_error,
+        root_mean_squared_error,
+        mean_percentage_error,
+        mean_absolute_percentage_error,
+        coefficient_of_determination,
+        mean_normalized_mean_absolute_error,
+        range_normalized_mean_absolute_error,
+        mean_normalized_root_mean_squared_error,
+        range_normalized_root_mean_squared_error,
+    ]
+
+    all_metric_names = [
+        "mean_absolute_error",
+        "mean_squared_error",
+        "root_mean_squared_error",
+        "mean_percentage_error",
+        "mean_absolute_percentage_error",
+        "coefficient_of_determination",
+        "normalized_mean_absolute_error",
+        "normalized_root_mean_squared_error",
+    ]
+
+    # create dictionary of metric names and functions
+    all_metric_dict = dict(zip(all_metric_names, all_metric_funcs))
+
+    if metrics == "all":
+        metric_dict = all_metric_dict
+    else:
+        metrics_set = set(metrics)
+        metric_dict = {k: all_metric_dict[k] for k in metrics if k in metrics_set}
+
+    # create metrics_df
+    metric_df = dict()
+    for name, func in metric_dict.items():
+        metric_df[name] = func(agreement_map, candidate_map, benchmark_map)
+
+    def is_nested_dict(d):
+        if not isinstance(d, dict):
+            return False
+        return any(isinstance(v, dict) for v in d.values())
+
+    if is_nested_dict(metric_df):
+        metric_df = pd.DataFrame.from_dict(metric_df, orient="index").transpose()
+        metric_df.reset_index(inplace=True)
+        metric_df.rename(columns={"index": "band"}, inplace=True)
+        metric_df["band"] = metric_df["band"].str.replace("band_", "")
+
+    else:
+        # dataarray
+        metric_df = pd.DataFrame(metric_df, index=[0])
+
+        # add band
+        metric_df.insert(0, "band", "1")
+
+    return metric_df

--- a/src/gval/comparison/pairing_functions.py
+++ b/src/gval/comparison/pairing_functions.py
@@ -387,3 +387,23 @@ def _make_pairing_dict_fn(
             )
 
     return nb.vectorize(nopython=True)(pairing_dict_fn)
+
+
+@nb.vectorize(nopython=True)
+def difference(c: Number, b: Number) -> Number:  # pragma: no cover
+    """
+    Calculates the difference between candidate and benchmark.
+
+    Parameters
+    ----------
+    c : Number
+        Candidate map value.
+    b : Number
+        Benchmark map value.
+
+    Returns
+    -------
+    Number
+        Difference between candidate and benchmark map values.
+    """
+    return c - b

--- a/src/gval/statistics/continuous_stat_funcs.py
+++ b/src/gval/statistics/continuous_stat_funcs.py
@@ -1,0 +1,415 @@
+"""
+Continuous Statistics Functions From Error Based Agreement Maps.
+"""
+
+from numbers import Number
+from typing import Union, Optional
+
+import xarray as xr
+import numpy as np
+
+from gval.statistics.continuous_stat_utils import convert_output, compute_error_if_none
+
+
+@compute_error_if_none
+@convert_output
+def mean_absolute_error(
+    error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+) -> Number:
+    """
+    Compute mean absolute error (MAE).
+
+    Either `error` or (`candidate_map` and `benchmark_map`) must be provided.
+
+    Parameters
+    ----------
+    error : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate minus benchmark error.
+    candidate_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate map.
+    benchmark_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Benchmark map.
+
+    Returns
+    -------
+    MAE : Number
+        Mean absolute error.
+
+    References
+    ----------
+    .. [1] [Mean absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error)
+    """
+    return np.abs(error).mean()
+
+
+@compute_error_if_none
+@convert_output
+def mean_squared_error(
+    error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+) -> Number:
+    """
+    Compute mean squared error (MSE).
+
+    Either `error` or (`candidate_map` and `benchmark_map`) must be provided.
+
+    Parameters
+    ----------
+    error : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate minus benchmark error.
+    candidate_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate map.
+    benchmark_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Benchmark map.
+
+    Returns
+    -------
+    MSE : Number
+        Mean squared error.
+
+    References
+    ----------
+    .. [1] [Mean squared error](https://en.wikipedia.org/wiki/Mean_squared_error)
+    """
+
+    return (error**2).mean()
+
+
+@compute_error_if_none
+@convert_output
+def root_mean_squared_error(
+    error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+) -> Number:
+    """
+    Compute root mean squared error (RMSE).
+
+    Either `error` or (`candidate_map` and `benchmark_map`) must be provided.
+
+    Parameters
+    ----------
+    error : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate minus benchmark error.
+    candidate_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate map.
+    benchmark_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Benchmark map.
+
+    Returns
+    -------
+    RMSE : Number
+        Root mean squared error.
+
+    References
+    ----------
+    .. [1] [Root mean square deviation](https://en.wikipedia.org/wiki/Root-mean-square_deviation)
+    """
+
+    return np.sqrt((error**2).mean())
+
+
+@compute_error_if_none
+@convert_output
+def mean_signed_error(
+    error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+) -> Number:
+    """
+    Compute mean signed error (MSiE).
+
+    Either `error` or (`candidate_map` and `benchmark_map`) must be provided.
+
+    Parameters
+    ----------
+    error : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate minus benchmark error.
+    candidate_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate map.
+    benchmark_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Benchmark map.
+
+    Returns
+    -------
+    MSiE : Number
+        Mean signed error.
+
+    References
+    ----------
+    .. [1] [Mean signed error](https://en.wikipedia.org/wiki/Mean_signed_difference)
+    """
+
+    return error.mean()
+
+
+@compute_error_if_none
+@convert_output
+def mean_percentage_error(
+    error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+) -> Number:
+    """
+    Compute mean percentage error (MPE).
+
+    Either (`error` and `benchmark_map`) or (`candidate_map` and `benchmark_map`) must be provided.
+
+    Parameters
+    ----------
+    error : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate minus benchmark error.
+    candidate_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate map.
+    benchmark_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Benchmark map.
+
+    Returns
+    -------
+    MPE : Number
+        Mean percentage error.
+
+    References
+    ----------
+    .. [1] [Mean percentage error](https://en.wikipedia.org/wiki/Mean_percentage_error)
+    """
+    return (error / benchmark_map.mean()).mean()
+
+
+@compute_error_if_none
+@convert_output
+def mean_absolute_percentage_error(
+    error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+) -> Number:
+    """
+    Compute mean absolute percentage error (MAPE).
+
+    Either (`error` and `benchmark_map`) or (`candidate_map` and `benchmark_map`) must be provided.
+
+    Parameters
+    ----------
+    error : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate minus benchmark error.
+    candidate_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate map.
+    benchmark_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Benchmark map.
+
+    Returns
+    -------
+    MAPE : Number
+        Mean absolute percentage error.
+
+    References
+    ----------
+    .. [1] [Mean absolute percentage error](https://en.wikipedia.org/wiki/Mean_absolute_percentage_error)
+    """
+
+    return np.abs(error / benchmark_map).mean()
+
+
+@compute_error_if_none
+@convert_output
+def mean_normalized_root_mean_squared_error(
+    error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+) -> Number:
+    """
+    Compute mean normalized root mean squared error (NRMSE).
+
+    Either (`error` and `benchmark_map`) or (`candidate_map` and `benchmark_map`) must be provided.
+
+    Parameters
+    ----------
+    error : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate minus benchmark error.
+    candidate_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate map.
+    benchmark_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Benchmark map.
+
+    Returns
+    -------
+    mNRMSE : Number
+        Mean normalized root mean squared error.
+
+    References
+    ----------
+    .. [1] [Normalized root-mean-square deviation](https://en.wikipedia.org/wiki/Root-mean-square_deviation#Normalized_root-mean-square_deviation)
+    """
+
+    return np.sqrt((error**2).mean()) / benchmark_map.mean()
+
+
+@compute_error_if_none
+@convert_output
+def range_normalized_root_mean_squared_error(
+    error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+) -> Number:
+    """
+    Compute range normalized root mean squared error (RNRMSE).
+
+    Either (`error` and `benchmark_map`) or (`candidate_map` and `benchmark_map`) must be provided.
+
+    Parameters
+    ----------
+    error : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate minus benchmark error.
+    candidate_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate map.
+    benchmark_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Benchmark map.
+
+    Returns
+    -------
+    rNRMSE : Number
+        Range normalized root mean squared error.
+
+    References
+    ----------
+    .. [1] [Normalized root-mean-square deviation](https://en.wikipedia.org/wiki/Root-mean-square_deviation#Normalized_root-mean-square_deviation)
+    """
+    return np.sqrt((error**2).mean()) / (benchmark_map.max() - benchmark_map.min())
+
+
+@compute_error_if_none
+@convert_output
+def mean_normalized_mean_absolute_error(
+    error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+) -> Number:
+    """
+    Compute mean normalized mean absolute error (NMAE).
+
+    Either (`error` and `benchmark_map`) or (`candidate_map` and `benchmark_map`) must be provided.
+
+    Parameters
+    ----------
+    error : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate minus benchmark error.
+    candidate_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate map.
+    benchmark_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Benchmark map.
+
+    Returns
+    -------
+    NMAE : Number
+        Normalized mean absolute error.
+
+    References
+    ----------
+    .. [1] [Normalized mean absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error#Normalized_mean_absolute_error)
+    """
+    return np.abs(error).mean() / benchmark_map.mean()
+
+
+@compute_error_if_none
+@convert_output
+def range_normalized_mean_absolute_error(
+    error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+) -> Number:
+    """
+    Compute range normalized mean absolute error (RNMAE).
+
+    Either (`error` and `benchmark_map`) or (`candidate_map` and `benchmark_map`) must be provided.
+
+    Parameters
+    ----------
+    error : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate minus benchmark error.
+    candidate_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate map.
+    benchmark_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Benchmark map.
+
+    Returns
+    -------
+    rNMAE : Number
+        Range normalized mean absolute error.
+
+    References
+    ----------
+    .. [1] [Normalized mean absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error#Normalized_mean_absolute_error)
+    """
+    return np.abs(error).mean() / (benchmark_map.max() - benchmark_map.min())
+
+
+@compute_error_if_none
+@convert_output
+def coefficient_of_determination(
+    error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+) -> Number:
+    """
+    Compute coefficient of determination (R2).
+
+    Either (error and benchmark_map) or (candidate_map and benchmark_map) must be provided.
+
+    Parameters
+    ----------
+    error : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate minus benchmark error.
+    candidate_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate map.
+    benchmark_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Benchmark map.
+
+    Returns
+    -------
+    R2 : Number
+        Coefficient of determination.
+
+    References
+    ----------
+    .. [1] [Coefficient of determination](https://en.wikipedia.org/wiki/Coefficient_of_determination)
+    """
+
+    return 1 - (error**2).sum() / ((benchmark_map - benchmark_map.mean()) ** 2).sum()
+
+
+@compute_error_if_none
+@convert_output
+def symmetric_mean_absolute_percentage_error(
+    error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+) -> Number:
+    """
+    Compute symmetric mean absolute percentage error (sMAPE).
+
+    Both `candidate_map` and `benchmark_map` must be provided. `error` can be provided to avoid recomputing it.
+
+    Parameters
+    ----------
+    error : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate minus benchmark error.
+    candidate_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Candidate map.
+    benchmark_map : Optional[Union[xr.DataArray, xr.Dataset]], default = None
+        Benchmark map.
+
+    Returns
+    -------
+    sMAPE : Number
+        Symmetric mean absolute percentage error.
+
+    References
+    ----------
+    .. [1] [Symmetric mean absolute percentage error](https://en.wikipedia.org/wiki/Symmetric_mean_absolute_percentage_error)
+    """
+    return (
+        2 * np.abs(error).sum() / (np.abs(candidate_map) + np.abs(benchmark_map)).sum()
+    )

--- a/src/gval/statistics/continuous_stat_utils.py
+++ b/src/gval/statistics/continuous_stat_utils.py
@@ -1,0 +1,89 @@
+"""
+Continuous Statistics Functions From Error Based Agreement Maps.
+"""
+
+from typing import Callable, Union, Optional
+from functools import wraps
+
+import xarray as xr
+
+
+def convert_output(func: Callable) -> Callable:  # pragma: no cover
+    """
+    Decorator that converts the output of a function to a different type.
+
+    If the output is an xarray.DataArray, it is converted to a single numeric value.
+    If the output is an xarray.Dataset, it is converted to a dictionary with the band names as keys.
+
+    Parameters
+    ----------
+    func : Callable
+        The function whose output is to be converted.
+
+    Returns
+    -------
+    wrapper : Callable
+        The decorated function.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # Call the decorated function
+        result = func(*args, **kwargs)
+
+        if isinstance(result, xr.DataArray):
+            # Convert to a single numeric value
+            return result.item()
+        elif isinstance(result, xr.Dataset):
+            # Convert to a dictionary with band names as keys
+            return {band: result[band].item() for band in result.data_vars}
+
+        return result
+
+    return wrapper
+
+
+def compute_error_if_none(func: Callable) -> Callable:  # pragma: no cover
+    """
+    Decorator to compute the error as the difference between the candidate map and benchmark map
+    if the error is not supplied.
+
+    The decorated function should have three positional arguments:
+    error: Union[xr.DataArray, xr.Dataset], optional
+        Candidate minus benchmark error.
+    benchmark_map: Union[xr.DataArray, xr.Dataset], optional
+        Benchmark map.
+    candidate_map: Union[xr.DataArray, xr.Dataset], optional
+        Candidate map.
+
+    The error is computed as the difference between the candidate_map and the benchmark_map.
+    If the error is provided, it is used directly.
+
+    If none of the arguments are provided, a ValueError is raised.
+
+    Parameters
+    ----------
+    func : Callable
+        Function to be decorated.
+
+    Returns
+    -------
+    wrapper : Callable
+        The decorated function.
+    """
+
+    def wrapper(
+        error: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+        benchmark_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+        candidate_map: Optional[Union[xr.DataArray, xr.Dataset]] = None,
+    ):
+        if error is None:
+            if benchmark_map is not None and candidate_map is not None:
+                error = candidate_map - benchmark_map
+            else:
+                raise ValueError(
+                    "Must provide either `error` or both `candidate_map` and `benchmark_map`."
+                )
+        return func(error, benchmark_map, candidate_map)
+
+    return wrapper

--- a/tests/cases_accessors.py
+++ b/tests/cases_accessors.py
@@ -278,3 +278,26 @@ def case_data_array_accessor_categorical_plot_fail(
     candidate_map, legend_labels, num_classes
 ):
     return candidate_map, legend_labels, num_classes
+
+
+candidate_maps = ["candidate_continuous_0.tif", "candidate_continuous_1.tif"]
+benchmark_maps = ["benchmark_continuous_0.tif", "benchmark_continuous_1.tif"]
+
+
+@parametrize(
+    "candidate_map, benchmark_map",
+    list(zip(candidate_maps, benchmark_maps)),
+)
+def case_data_array_accessor_continuous(candidate_map, benchmark_map):
+    return _load_xarray(candidate_map), _load_xarray(benchmark_map)
+
+
+@parametrize(
+    "candidate_map, benchmark_map",
+    list(zip(candidate_maps, benchmark_maps)),
+)
+def case_data_set_accessor_continuous(candidate_map, benchmark_map):
+    return (
+        _load_xarray(candidate_map, band_as_variable=True),
+        _load_xarray(benchmark_map, band_as_variable=True),
+    )

--- a/tests/cases_compare.py
+++ b/tests/cases_compare.py
@@ -228,6 +228,19 @@ def case_pairing_dict_fn(c, b, pairing_dict, expected_value):
     return c, b, pairing_dict, expected_value
 
 
+difference_inputs = [
+    (1, 3, -2),
+    (10.0, 4.0, 6.0),
+    (np.nan, 10, np.nan),
+    (np.nan, np.nan, np.nan),
+]
+
+
+@parametrize("c, b, expected_value", difference_inputs)
+def case_difference(c, b, expected_value):
+    return c, b, expected_value
+
+
 crosstab_dfs = [
     (
         pd.DataFrame({"zone": [0, 1, 2], 0: [10, 100, 200], 1: [50, 25, 100]}),

--- a/tests/cases_compute_continuous_metrics.py
+++ b/tests/cases_compute_continuous_metrics.py
@@ -1,0 +1,72 @@
+"""
+Test functionality for computing_continuous_metrics.py
+"""
+
+# __all__ = ['*']
+__author__ = "Fernando Aristizabal"
+
+from pytest_cases import parametrize
+import pandas as pd
+
+from tests.conftest import _load_xarray
+
+
+expected_dfs = [
+    pd.DataFrame(
+        {
+            "band": {0: "1"},
+            "mean_absolute_error": 0.3173885941505432,
+            "mean_squared_error": 0.30277130007743835,
+            "root_mean_squared_error": 0.5502465963363647,
+            "mean_percentage_error": 0.015025136061012745,
+            "mean_absolute_percentage_error": 0.15956786274909973,
+            "coefficient_of_determination": -0.06615996360778809,
+            "normalized_mean_absolute_error": 0.16163060069084167,
+            "normalized_root_mean_squared_error": 0.27127230167388916,
+        }
+    ),
+    pd.DataFrame(
+        {
+            "band": ["1", "2"],
+            "mean_absolute_error": [0.48503121733665466, 0.48503121733665466],
+            "mean_squared_error": [0.5341722369194031, 0.5341722369194031],
+            "root_mean_squared_error": [0.7308709025382996, 0.7308709025382996],
+        }
+    ),
+]
+
+candidate_maps = ["candidate_continuous_0.tif", "candidate_continuous_1.tif"]
+benchmark_maps = ["benchmark_continuous_0.tif", "benchmark_continuous_1.tif"]
+
+all_load_options = [
+    {"mask_and_scale": True},
+    {"mask_and_scale": True, "band_as_variable": True},
+]
+
+metrics_input = [
+    "all",
+    ["mean_absolute_error", "mean_squared_error", "root_mean_squared_error"],
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, metrics, expected_df",
+    list(
+        zip(
+            candidate_maps,
+            benchmark_maps,
+            all_load_options,
+            metrics_input,
+            expected_dfs,
+        )
+    ),
+)
+def case_compute_continuous_metrics_success(
+    candidate_map, benchmark_map, load_options, metrics, expected_df
+):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        metrics,
+        expected_df,
+    )

--- a/tests/cases_continuous_metrics.py
+++ b/tests/cases_continuous_metrics.py
@@ -1,0 +1,309 @@
+"""
+Cases for testing continuous value metrics.
+"""
+
+# __all__ = ['*']
+__author__ = ["Fernando Aristizabal"]
+
+from pytest_cases import parametrize
+
+from tests.conftest import _load_xarray
+
+
+candidate_maps = ["candidate_continuous_0.tif", "candidate_continuous_1.tif"]
+benchmark_maps = ["benchmark_continuous_0.tif", "benchmark_continuous_1.tif"]
+
+all_load_options = [
+    {"mask_and_scale": True},
+    {"mask_and_scale": True, "band_as_variable": True},
+]
+
+ev_mean_absolute_error = [
+    0.3173885941505432,
+    {"band_1": 0.48503121733665466, "band_2": 0.48503121733665466},
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, expected_value",
+    list(zip(candidate_maps, benchmark_maps, all_load_options, ev_mean_absolute_error)),
+)
+def case_mean_absolute_error(
+    candidate_map, benchmark_map, load_options, expected_value
+):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        expected_value,
+    )
+
+
+ev_mean_squared_error = [
+    0.30277130007743835,
+    {"band_1": 0.5341722369194031, "band_2": 0.5341722369194031},
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, expected_value",
+    list(zip(candidate_maps, benchmark_maps, all_load_options, ev_mean_squared_error)),
+)
+def case_mean_squared_error(candidate_map, benchmark_map, load_options, expected_value):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        expected_value,
+    )
+
+
+ev_root_mean_squared_error = [
+    0.5502465963363647,
+    {"band_1": 0.7308709025382996, "band_2": 0.7308709025382996},
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, expected_value",
+    list(
+        zip(
+            candidate_maps, benchmark_maps, all_load_options, ev_root_mean_squared_error
+        )
+    ),
+)
+def case_root_mean_squared_error(
+    candidate_map, benchmark_map, load_options, expected_value
+):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        expected_value,
+    )
+
+
+ev_mean_signed_error = [
+    0.02950434572994709,
+    {"band_1": -0.3584839105606079, "band_2": 0.3584839105606079},
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, expected_value",
+    list(zip(candidate_maps, benchmark_maps, all_load_options, ev_mean_signed_error)),
+)
+def case_mean_signed_error(candidate_map, benchmark_map, load_options, expected_value):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        expected_value,
+    )
+
+
+ev_mean_percentage_error = [
+    0.015025136061012745,
+    {"band_1": -0.1585608273744583, "band_2": 0.1368602067232132},
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, expected_value",
+    list(
+        zip(candidate_maps, benchmark_maps, all_load_options, ev_mean_percentage_error)
+    ),
+)
+def case_mean_percentage_error(
+    candidate_map, benchmark_map, load_options, expected_value
+):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        expected_value,
+    )
+
+
+ev_mean_absolute_percentage_error = [
+    0.15956786274909973,
+    {"band_1": 0.20223499834537506, "band_2": 0.15323485434055328},
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, expected_value",
+    list(
+        zip(
+            candidate_maps,
+            benchmark_maps,
+            all_load_options,
+            ev_mean_absolute_percentage_error,
+        )
+    ),
+)
+def case_mean_absolute_percentage_error(
+    candidate_map, benchmark_map, load_options, expected_value
+):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        expected_value,
+    )
+
+
+ev_mean_normalized_root_absolute_error = [
+    0.2802138924598694,
+    {"band_1": 0.32327112555503845, "band_2": 0.2790282368659973},
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, expected_value",
+    list(
+        zip(
+            candidate_maps,
+            benchmark_maps,
+            all_load_options,
+            ev_mean_normalized_root_absolute_error,
+        )
+    ),
+)
+def case_mean_normalized_root_mean_squared_error(
+    candidate_map, benchmark_map, load_options, expected_value
+):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        expected_value,
+    )
+
+
+ev_range_normalized_root_mean_squared_error = [
+    0.4702962636947632,
+    {"band_1": 0.8913060426712036, "band_2": 0.42992404103279114},
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, expected_value",
+    list(
+        zip(
+            candidate_maps,
+            benchmark_maps,
+            all_load_options,
+            ev_range_normalized_root_mean_squared_error,
+        )
+    ),
+)
+def case_range_normalized_root_mean_squared_error(
+    candidate_map, benchmark_map, load_options, expected_value
+):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        expected_value,
+    )
+
+
+ev_mean_normalized_mean_absolute_error = [
+    0.16163060069084167,
+    {"band_1": 0.21453391015529633, "band_2": 0.18517279624938965},
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, expected_value",
+    list(
+        zip(
+            candidate_maps,
+            benchmark_maps,
+            all_load_options,
+            ev_mean_normalized_mean_absolute_error,
+        )
+    ),
+)
+def case_mean_normalized_mean_absolute_error(
+    candidate_map, benchmark_map, load_options, expected_value
+):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        expected_value,
+    )
+
+
+ev_range_normalized_mean_absolute_error = [
+    0.27127230167388916,
+    {"band_1": 0.5915015339851379, "band_2": 0.2853124737739563},
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, expected_value",
+    list(
+        zip(
+            candidate_maps,
+            benchmark_maps,
+            all_load_options,
+            ev_range_normalized_mean_absolute_error,
+        )
+    ),
+)
+def case_range_normalized_mean_absolute_error(
+    candidate_map, benchmark_map, load_options, expected_value
+):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        expected_value,
+    )
+
+
+ev_coefficient_of_determination = [
+    -0.06615996360778809,
+    {"band_1": -2.829420804977417, "band_2": 0.10903036594390869},
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, expected_value",
+    list(
+        zip(
+            candidate_maps,
+            benchmark_maps,
+            all_load_options,
+            ev_coefficient_of_determination,
+        )
+    ),
+)
+def case_coefficient_of_determination(
+    candidate_map, benchmark_map, load_options, expected_value
+):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        expected_value,
+    )
+
+
+ev_symmetric_mean_absolute_percentage_error = [
+    0.1628540771054295,
+    {"band_1": 0.19877496825251173, "band_2": 0.19877496825251173},
+]
+
+
+@parametrize(
+    "candidate_map, benchmark_map, load_options, expected_value",
+    list(
+        zip(
+            candidate_maps,
+            benchmark_maps,
+            all_load_options,
+            ev_symmetric_mean_absolute_percentage_error,
+        )
+    ),
+)
+def case_symmetric_mean_absolute_percentage_error(
+    candidate_map, benchmark_map, load_options, expected_value
+):
+    return (
+        _load_xarray(candidate_map, **load_options),
+        _load_xarray(benchmark_map, **load_options),
+        expected_value,
+    )

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -231,3 +231,32 @@ def test_data_array_accessor_categorical_plot_fail(
     candidate_map.data = np.random.choice(np.arange(num_classes), candidate_map.shape)
     with raises(ValueError):
         _ = candidate_map.gval.cat_plot(legend_labels=legend_labels)
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map",
+    glob="data_array_accessor_continuous",
+)
+def test_data_array_accessor_continuous(candidate_map, benchmark_map):
+    agreement_map, metrics_df = candidate_map.gval.continuous_compare(
+        benchmark_map=benchmark_map, metrics="all"
+    )
+
+    assert isinstance(agreement_map, xr.DataArray)
+    assert isinstance(metrics_df, DataFrame)
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map",
+    glob="data_set_accessor_continuous",
+)
+def test_data_set_accessor_continuous(
+    candidate_map,
+    benchmark_map,
+):
+    agreement_map, metrics_df = candidate_map.gval.continuous_compare(
+        benchmark_map=benchmark_map, metrics="all"
+    )
+
+    assert isinstance(agreement_map, xr.Dataset)
+    assert isinstance(metrics_df, DataFrame)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -21,6 +21,7 @@ from gval.comparison.pairing_functions import (
     _make_pairing_dict,
     _make_pairing_dict_fn,
     PairingDict,
+    difference,
 )
 from gval.comparison.agreement import _compute_agreement_map
 from gval.comparison.tabulation import (
@@ -115,6 +116,13 @@ def test_pairing_dict_fn(c, b, pairing_dict, expected_value):
     computed_value = pairing_dict_fn(c, b)
 
     np.testing.assert_equal(computed_value, expected_value)
+
+
+@parametrize_with_cases("c, b, expected_value", glob="difference")
+def test_difference(c, b, expected_value):
+    """Tests difference comparison function"""
+
+    np.testing.assert_equal(difference(c, b), expected_value)
 
 
 #################################################################################

--- a/tests/test_compute_continuous_metrics.py
+++ b/tests/test_compute_continuous_metrics.py
@@ -1,0 +1,31 @@
+"""
+Test functionality for computing_continuous_metrics.py
+"""
+
+# __all__ = ['*']
+__author__ = "Fernando Aristizabal"
+
+
+import pandas as pd
+from pytest_cases import parametrize_with_cases
+
+from gval.comparison.compute_continuous_metrics import _compute_continuous_metrics
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, metrics, expected_df",
+    glob="compute_continuous_metrics_success",
+)
+def test_compute_continuous_metrics_success(
+    candidate_map, benchmark_map, metrics, expected_df
+):
+    """tests continuous metrics functions"""
+
+    # compute continuous metrics
+    metrics_df = _compute_continuous_metrics(
+        candidate_map=candidate_map, benchmark_map=benchmark_map, metrics=metrics
+    )
+
+    pd.testing.assert_frame_equal(
+        metrics_df, expected_df, check_dtype=False
+    ), "Compute statistics did not return expected values"

--- a/tests/test_continuous_metrics.py
+++ b/tests/test_continuous_metrics.py
@@ -1,0 +1,164 @@
+"""
+Test functionality for continuous value metrics.
+"""
+
+# __all__ = ['*']
+
+from functools import wraps
+
+import numpy as np
+from pytest_cases import parametrize_with_cases
+
+from tests.conftest import _assert_pairing_dict_equal
+from gval.statistics import continuous_stat_funcs
+
+
+def assert_logic_decorator(test_function):
+    @wraps(test_function)
+    def wrapper(candidate_map, benchmark_map, expected_value):
+        # Call the test function
+        result = test_function(candidate_map, benchmark_map, expected_value)
+
+        # Implement the assert logic
+        if isinstance(expected_value, dict):
+            _assert_pairing_dict_equal(result, expected_value)
+        else:
+            np.testing.assert_almost_equal(result, expected_value)
+
+    return wrapper
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, expected_value",
+    glob="mean_absolute_error",
+)
+@assert_logic_decorator
+def test_mean_absolute_error(candidate_map, benchmark_map, expected_value):
+    return continuous_stat_funcs.mean_absolute_error(None, candidate_map, benchmark_map)
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, expected_value",
+    glob="mean_squared_error",
+)
+@assert_logic_decorator
+def test_mean_squared_error(candidate_map, benchmark_map, expected_value):
+    return continuous_stat_funcs.mean_squared_error(None, candidate_map, benchmark_map)
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, expected_value",
+    glob="root_mean_squared_error",
+)
+@assert_logic_decorator
+def test_root_mean_squared_error(candidate_map, benchmark_map, expected_value):
+    return continuous_stat_funcs.root_mean_squared_error(
+        None, candidate_map, benchmark_map
+    )
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, expected_value",
+    glob="mean_signed_error",
+)
+@assert_logic_decorator
+def test_mean_signed_error(candidate_map, benchmark_map, expected_value):
+    return continuous_stat_funcs.mean_signed_error(None, candidate_map, benchmark_map)
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, expected_value",
+    glob="mean_percentage_error",
+)
+@assert_logic_decorator
+def test_mean_percentage_error(candidate_map, benchmark_map, expected_value):
+    return continuous_stat_funcs.mean_percentage_error(
+        None, candidate_map, benchmark_map
+    )
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, expected_value",
+    glob="mean_absolute_percentage_error",
+)
+@assert_logic_decorator
+def test_mean_absolute_percentage_error(candidate_map, benchmark_map, expected_value):
+    return continuous_stat_funcs.mean_absolute_percentage_error(
+        None, candidate_map, benchmark_map
+    )
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, expected_value",
+    glob="mean_normalized_root_mean_squared_error",
+)
+@assert_logic_decorator
+def test_mean_normalized_root_mean_squared_error(
+    candidate_map, benchmark_map, expected_value
+):
+    return continuous_stat_funcs.mean_normalized_root_mean_squared_error(
+        None, candidate_map, benchmark_map
+    )
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, expected_value",
+    glob="range_normalized_root_mean_squared_error",
+)
+@assert_logic_decorator
+def test_range_normalized_root_mean_squared_error(
+    candidate_map, benchmark_map, expected_value
+):
+    return continuous_stat_funcs.range_normalized_root_mean_squared_error(
+        None, candidate_map, benchmark_map
+    )
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, expected_value",
+    glob="mean_normalized_mean_absolute_error",
+)
+@assert_logic_decorator
+def test_mean_normalized_mean_absolute_error(
+    candidate_map, benchmark_map, expected_value
+):
+    return continuous_stat_funcs.mean_normalized_mean_absolute_error(
+        None, candidate_map, benchmark_map
+    )
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, expected_value",
+    glob="range_normalized_mean_absolute_error",
+)
+@assert_logic_decorator
+def test_range_normalized_mean_absolute_error(
+    candidate_map, benchmark_map, expected_value
+):
+    return continuous_stat_funcs.range_normalized_mean_absolute_error(
+        None, candidate_map, benchmark_map
+    )
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, expected_value",
+    glob="coefficient_of_determination",
+)
+@assert_logic_decorator
+def test_coefficient_of_determination(candidate_map, benchmark_map, expected_value):
+    return continuous_stat_funcs.coefficient_of_determination(
+        None, candidate_map, benchmark_map
+    )
+
+
+@parametrize_with_cases(
+    "candidate_map, benchmark_map, expected_value",
+    glob="symmetric_mean_absolute_percentage_error",
+)
+@assert_logic_decorator
+def test_symmetric_mean_absolute_percentage_error(
+    candidate_map, benchmark_map, expected_value
+):
+    return continuous_stat_funcs.symmetric_mean_absolute_percentage_error(
+        None, candidate_map, benchmark_map
+    )


### PR DESCRIPTION
Continuous Compare Implementation, Closes #110
- Removed information loss TODO comments within `agreement.py`
- Using homogenize accessor method within `categorical_compare()` accessor method to avoid code reuse.
- Changed homogenize docstring to better represent function.
- Added `difference()` pairing function to compute error based (candidate - benchmark) agreement maps.
- Added `continuous_stat_funcs.py` with continuous value metrics.
- Added `compute_continuous_metrics.py` with private function to compute continuous value metrics from maps.
- Added `continuous_stat_utils.py` for continuous stat decorators: `convert_output()` and `compute_error_if_none`
- Added `docs/sphinx/_build/` to `.gitignore`.