### PR TITLE
Apply pairing dict hotfix and setup new test case

### DIFF
--- a/tests/cases_accessors.py
+++ b/tests/cases_accessors.py
@@ -20,6 +20,7 @@ candidate_maps = [
     _load_xarray("candidate_map_0_accessor.tif", mask_and_scale=True, chunks="auto"),
     _load_xarray("candidate_map_0_accessor.tif", mask_and_scale=True),
     _load_xarray("candidate_map_0_accessor.tif", mask_and_scale=True),
+    _load_xarray("candidate_map_0_accessor.tif", mask_and_scale=True),
 ]
 benchmark_maps = [
     _load_xarray("benchmark_map_0_accessor.tif", mask_and_scale=True),
@@ -28,6 +29,7 @@ benchmark_maps = [
     ),
     _load_gpkg("polygons_two_class_categorical.gpkg"),
     _load_xarray("benchmark_map_0_accessor.tif", mask_and_scale=True, chunks="auto"),
+    _load_xarray("benchmark_map_0_accessor.tif", mask_and_scale=True),
     _load_xarray("benchmark_map_0_accessor.tif", mask_and_scale=True),
     _load_xarray("benchmark_map_0_accessor.tif", mask_and_scale=True),
 ]
@@ -73,15 +75,32 @@ plot_maps = [
 ]
 
 
-positive_cat = np.array([2, 2, 2, 2, 2, 2])
-negative_cat = np.array([[0, 1], [0, 1], [0, 1], [0, 1], [0, 1], [0, 1]])
-rasterize_attrs = [None, None, ["category"], None, None, None]
-memory_strategy = ["normal", "normal", "normal", "normal", "moderate", "aggressive"]
+positive_cat = np.array([2, 2, 2, 2, 2, 2, 2])
+negative_cat = np.array([[0, 1], [0, 1], [0, 1], [0, 1], [0, 1], [0, 1], [0, 1]])
+rasterize_attrs = [None, None, ["category"], None, None, None, None]
+memory_strategy = [
+    "normal",
+    "normal",
+    "normal",
+    "normal",
+    "moderate",
+    "aggressive",
+    "normal",
+]
 exception_list = [OSError, ValueError, TypeError]
+comparison_funcs = [
+    "szudzik",
+    "szudzik",
+    "szudzik",
+    "szudzik",
+    "szudzik",
+    "szudzik",
+    "pairing_dict",
+]
 
 
 @parametrize(
-    "candidate_map, benchmark_map, positive_categories, negative_categories, rasterize_attributes, memory_strategies",
+    "candidate_map, benchmark_map, positive_categories, negative_categories, rasterize_attributes, memory_strategies, comparison_function",
     list(
         zip(
             candidate_maps,
@@ -90,6 +109,7 @@ exception_list = [OSError, ValueError, TypeError]
             negative_cat,
             rasterize_attrs,
             memory_strategy,
+            comparison_funcs,
         )
     ),
 )
@@ -100,6 +120,7 @@ def case_data_array_accessor_success(
     negative_categories,
     rasterize_attributes,
     memory_strategies,
+    comparison_function,
 ):
     return (
         candidate_map,
@@ -108,6 +129,7 @@ def case_data_array_accessor_success(
         negative_categories,
         rasterize_attributes,
         memory_strategies,
+        comparison_function,
     )
 
 

--- a/tests/cases_accessors.py
+++ b/tests/cases_accessors.py
@@ -20,7 +20,6 @@ candidate_maps = [
     _load_xarray("candidate_map_0_accessor.tif", mask_and_scale=True, chunks="auto"),
     _load_xarray("candidate_map_0_accessor.tif", mask_and_scale=True),
     _load_xarray("candidate_map_0_accessor.tif", mask_and_scale=True),
-    _load_xarray("candidate_map_0_accessor.tif", mask_and_scale=True),
 ]
 benchmark_maps = [
     _load_xarray("benchmark_map_0_accessor.tif", mask_and_scale=True),
@@ -29,7 +28,6 @@ benchmark_maps = [
     ),
     _load_gpkg("polygons_two_class_categorical.gpkg"),
     _load_xarray("benchmark_map_0_accessor.tif", mask_and_scale=True, chunks="auto"),
-    _load_xarray("benchmark_map_0_accessor.tif", mask_and_scale=True),
     _load_xarray("benchmark_map_0_accessor.tif", mask_and_scale=True),
     _load_xarray("benchmark_map_0_accessor.tif", mask_and_scale=True),
 ]
@@ -103,8 +101,24 @@ comparison_funcs = [
     "candidate_map, benchmark_map, positive_categories, negative_categories, rasterize_attributes, memory_strategies, comparison_function",
     list(
         zip(
-            candidate_maps,
-            benchmark_maps,
+            [
+                candidate_maps[0],
+                candidate_maps[1],
+                candidate_maps[2],
+                candidate_maps[3],
+                candidate_maps[4],
+                candidate_maps[5],
+                candidate_maps[0],
+            ],
+            [
+                benchmark_maps[0],
+                benchmark_maps[1],
+                benchmark_maps[2],
+                benchmark_maps[3],
+                benchmark_maps[4],
+                benchmark_maps[5],
+                benchmark_maps[0],
+            ],
             positive_cat,
             negative_cat,
             rasterize_attrs,

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -12,7 +12,7 @@ from gval.utils.loading_datasets import (
 
 
 @parametrize_with_cases(
-    "candidate_map, benchmark_map, positive_categories, negative_categories, rasterize_attributes, memory_strategies",
+    "candidate_map, benchmark_map, positive_categories, negative_categories, rasterize_attributes, memory_strategies, comparison_function",
     glob="data_array_accessor_success",
 )
 def test_data_array_accessor_success(
@@ -22,6 +22,7 @@ def test_data_array_accessor_success(
     negative_categories,
     rasterize_attributes,
     memory_strategies,
+    comparison_function,
 ):
     adjust_memory_strategy(memory_strategies)
 
@@ -34,6 +35,9 @@ def test_data_array_accessor_success(
         positive_categories=positive_categories,
         negative_categories=negative_categories,
         rasterize_attributes=rasterize_attributes,
+        comparison_function=comparison_function,
+        allow_candidate_values=[1, 2, np.nan],
+        allow_benchmark_values=[0, 2, np.nan],
     )
 
     if rasterize_attributes is None:


### PR DESCRIPTION
This addresses the issue #146 although there is still issue #147 that remains after this fix.

## Changes

- gval_xarray.py: Add decorator to check for pairing dict functions and add pairing_dict argument to compute_crosstab.
- compute_comparison.py:  Add decorator function to get comparison function from string
- cases_accessors/test/accessors.py:  Add test case for pairing_dict_fn in compute categorical comparison.
