### PR TITLE
Replace deprecated set_crs function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 requires-python = ">=3.8"
 keywords = ["geospatial", "evaluations"]
 license = {text = "MIT"}
-version = "0.2.7"
+version = "0.2.7-1"
 dynamic = ["readme", "dependencies"]
 
 [project.optional-dependencies]

--- a/src/gval/comparison/agreement.py
+++ b/src/gval/comparison/agreement.py
@@ -131,7 +131,7 @@ def _compute_agreement_map(
         """
 
         # sets CRS that is lost with `xr.apply_ufunc`
-        agreement_map.rio.set_crs(crs, inplace=True)
+        agreement_map.rio.write_crs(crs, inplace=True)
 
         # setting agreement map nodata and encoded nodata
         if nodata is not None:

--- a/tests/data_generation/data_tests.py
+++ b/tests/data_generation/data_tests.py
@@ -85,7 +85,7 @@ def generate_aligned_and_agreement_maps(
                     allow_benchmark_values=allow_benchmark_values,
                 )
 
-                agreement_map_computed.rio.set_crs(cam.rio.crs)
+                agreement_map_computed.rio.write_crs(cam.rio.crs, inplace=True)
 
                 agreement_map_computed.rio.set_nodata(-9999)
                 if np.nan in agreement_map_computed:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -11,7 +11,7 @@ import gval  # noqa: F401
     glob="categorical_plot_success",
 )
 def test_categorical_plot_success(candidate_map, crs, entries):
-    candidate_map.rio.set_crs(crs)
+    candidate_map.rio.write_crs(crs, inplace=True)
     viz_object = candidate_map.gval.cat_plot(basemap=None)
     assert len(viz_object.axes.get_legend().texts) == entries
 


### PR DESCRIPTION
This change addresses inundation-mapping issue [1229](https://github.com/NOAA-OWP/inundation-mapping/issues/1229) regarding a deprecated function notice.

## Changes

- agreement.py: Change set_crs to write_crs.