### PR TITLE
Deprecated function removal

### DIFF
--- a/LICENSE.MD
+++ b/LICENSE.MD
@@ -1,3 +1,17 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-----------------
+
 “Software code created by U.S. Government employees is not subject to copyright
 in the United States (17 U.S.C. §105). The United States/Department of Commerce
 reserve all rights to seek and obtain copyright protection in countries other
@@ -5,3 +19,5 @@ than the United States for Software authored in its entirety by the Department
 of Commerce. To this end, the Department of Commerce hereby grants to Recipient
 a royalty-free, nonexclusive license to use, copy, and create derivative works
 of the Software outside of the United States.”
+
+-----------------

--- a/docs/sphinx/SphinxCatalogTutorial.ipynb
+++ b/docs/sphinx/SphinxCatalogTutorial.ipynb
@@ -884,7 +884,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/sphinx/SphinxContinuousTutorial.ipynb
+++ b/docs/sphinx/SphinxContinuousTutorial.ipynb
@@ -710,7 +710,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/sphinx/SphinxTutorial.ipynb
+++ b/docs/sphinx/SphinxTutorial.ipynb
@@ -40,7 +40,7 @@
    "id": "64da5e7b",
    "metadata": {},
    "source": [
-    "It is preferred to use masking and scaling by default.  If your original data does not have nodata or does not have nodata assigned, please assign using: `rio.set_nodata(<your_nodata_value>)`"
+    "It is preferred to use masking and scaling by default.  If your original data does not have nodata or does not have nodata assigned, please assign using: `rio.write_nodata(<your_nodata_value>, inplace=True)`"
    ]
   },
   {
@@ -1158,7 +1158,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/notebooks/Tutorial.ipynb
+++ b/notebooks/Tutorial.ipynb
@@ -40,7 +40,7 @@
    "id": "64da5e7b",
    "metadata": {},
    "source": [
-    "It is preferred to use masking and scaling by default.  If your original data does not have nodata or does not have nodata assigned, please assign using: `rio.set_nodata(<your_nodata_value>)`"
+    "It is preferred to use masking and scaling by default.  If your original data does not have nodata or does not have nodata assigned, please assign using: `rio.write_nodata(<your_nodata_value>, inplace=True)`"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 requires-python = ">=3.8"
 keywords = ["geospatial", "evaluations"]
 license = {text = "MIT"}
-version = "0.2.7-1"
+version = "0.2.8"
 dynamic = ["readme", "dependencies"]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 requires-python = ">=3.8"
 keywords = ["geospatial", "evaluations"]
 license = {text = "MIT"}
-version = "0.2.8"
+version = "0.2.9"
 dynamic = ["readme", "dependencies"]
 
 [project.optional-dependencies]

--- a/src/gval/comparison/agreement.py
+++ b/src/gval/comparison/agreement.py
@@ -146,7 +146,7 @@ def _compute_agreement_map(
                     nodata, encoded=encode_nodata, inplace=True
                 )
             else:
-                agreement_map.rio.set_nodata(nodata, inplace=True)
+                agreement_map.rio.write_nodata(nodata, inplace=True)
 
         return agreement_map
 

--- a/src/gval/homogenize/rasterize.py
+++ b/src/gval/homogenize/rasterize.py
@@ -60,7 +60,7 @@ def _rasterize_data(
     if isinstance(candidate_map, xr.DataArray):
         rasterized_data = rasterized_data.to_array()
         # Nodata resolve
-        rasterized_data.rio.set_nodata(np.nan)
+        rasterized_data.rio.write_nodata(np.nan, encoded=True, inplace=True)
         rasterized_data.rio.write_nodata(
             candidate_map.rio.encoded_nodata, encoded=True, inplace=True
         )
@@ -94,7 +94,9 @@ def _rasterize_data(
         for var_name in rasterized_data.data_vars.keys():
             # Resolve nodata issues
 
-            rasterized_data[var_name] = rasterized_data[var_name].rio.set_nodata(np.nan)
+            rasterized_data[var_name] = rasterized_data[var_name].rio.write_nodata(
+                np.nan, encoded=True, inplace=True
+            )
 
             if rasterized_data[var_name].rio.encoded_nodata is None:
                 rasterized_data[var_name] = rasterized_data[var_name].rio.write_nodata(

--- a/tests/data_generation/data_tests.py
+++ b/tests/data_generation/data_tests.py
@@ -87,7 +87,7 @@ def generate_aligned_and_agreement_maps(
 
                 agreement_map_computed.rio.write_crs(cam.rio.crs, inplace=True)
 
-                agreement_map_computed.rio.set_nodata(-9999)
+                agreement_map_computed.rio.write_nodata(-9999, inplace=True)
                 if np.nan in agreement_map_computed:
                     agreement_map_computed = xr.where(
                         np.isnan(agreement_map_computed), -9999, agreement_map_computed

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -280,7 +280,11 @@ def test_stac_catalog_comparison_success(
     stac_clog = catalog_compare(**arguments)
 
     pd.testing.assert_frame_equal(
-        stac_clog, expected_catalog_df, check_dtype=False, check_index_type=False
+        stac_clog,
+        expected_catalog_df,
+        check_dtype=False,
+        check_index_type=False,
+        check_like=True,
     ), "Computed catalog did not match the expected catalog df"
 
 


### PR DESCRIPTION
Removing last remaining deprecated functions in code and notebooks.

## Changes

- Tutorial.ipynb, SphinxTutorial.ipnyb:  Replace rio.set_crs with rio.write_crs
- agreement.py:  Replace rio.set_nodata with rio.write_nodata
- rasterize.py: Replace rio.set_nodata with rio.write.nodata
- data_test.py: Replace rio.set_nodata with rio.write.nodata
- pyproject.toml:  Update version