### PR TITLE
Different candidate and benchmark positive and negative classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ authors = [
     {name = "Fernando Aristizabal", email = "fernando.aristizabal@noaa.gov"},
     {name = "Gregory Petrochenkov", email = "gregory.petrochenkov@noaa.gov"}
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["geospatial", "evaluations"]
 license = {text = "MIT"}
-version = "0.2.10"
+version = "0.2.11"
 dynamic = ["readme", "dependencies"]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 rioxarray>=0.13.4
 dask>=2023.5.0,<2025
+dask[dataframe]>=2023.5.0,<2025
 pandera==0.24.0
 shapely==2.1.1
 geocube>=0.7.1

--- a/src/gval/accessors/gval_dataframe.py
+++ b/src/gval/accessors/gval_dataframe.py
@@ -1,5 +1,5 @@
 from numbers import Number
-from typing import Union, Iterable, Optional, List
+from typing import Union, Iterable, Optional, List, Dict
 
 import pandas as pd
 from shapely import Geometry
@@ -28,8 +28,12 @@ class GVALDataFrame:
 
     def compute_categorical_metrics(
         self,
-        positive_categories: Union[Number, Iterable[Number]],
-        negative_categories: Union[Number, Iterable[Number]],
+        positive_categories: Union[
+            Number, Iterable[Number], Dict[str, Union[Number, Iterable[Number]]]
+        ],
+        negative_categories: Union[
+            Number, Iterable[Number], Dict[str, Union[Number, Iterable[Number]]]
+        ],
         metrics: Union[str, Iterable[str]] = "all",
         average: str = "micro",
         weights: Optional[Iterable[Number]] = None,
@@ -42,9 +46,9 @@ class GVALDataFrame:
         ----------
         crosstab_df : DataFrame[Crosstab_df]
             Crosstab DataFrame with candidate, benchmark, and agreement values as well as the counts for each occurrence.
-        positive_categories : Optional[Union[Number, Iterable[Number]]]
+        positive_categories : Optional[Union[Number, Iterable[Number], Dict[str, Union[Number, Iterable[Number]]]]]
             Number or list of numbers representing the values to consider as the positive condition. For average types "macro" and "weighted", this represents the categories to compute metrics for.
-        negative_categories : Optional[Union[Number, Iterable[Number]]], default = None
+        negative_categories : Optional[UUnion[Number, Iterable[Number], Dict[str, Union[Number, Iterable[Number]]]]], default = None
             Number or list of numbers representing the values to consider as the negative condition. This should be set to None when no negative categories are used or when the average type is "macro" or "weighted".
         metrics : Union[str, Iterable[str]], default = "all"
             String or list of strings representing metrics to compute.

--- a/src/gval/accessors/gval_xarray.py
+++ b/src/gval/accessors/gval_xarray.py
@@ -113,7 +113,9 @@ class GVALXarray:
     def categorical_compare(
         self,
         benchmark_map: Union[gpd.GeoDataFrame, xr.Dataset, xr.DataArray],
-        positive_categories: Optional[Union[Number, Iterable[Number]]],
+        positive_categories: Union[
+            Number, Iterable[Number], Dict[str, Union[Number, Iterable[Number]]]
+        ],
         comparison_function: Union[
             Callable, nb.np.ufunc.dufunc.DUFunc, np.ufunc, np.vectorize, str
         ] = "szudzik",
@@ -126,7 +128,9 @@ class GVALXarray:
         nodata: Optional[Number] = None,
         encode_nodata: Optional[bool] = False,
         exclude_value: Optional[Number] = None,
-        negative_categories: Optional[Union[Number, Iterable[Number]]] = None,
+        negative_categories: Union[
+            Number, Iterable[Number], Dict[str, Union[Number, Iterable[Number]]]
+        ] = None,
         average: str = "micro",
         weights: Optional[Iterable[Number]] = None,
         rasterize_attributes: Optional[list] = None,
@@ -164,7 +168,7 @@ class GVALXarray:
         ----------
         benchmark_map: Union[gpd.GeoDataFrame, xr.Dataset, xr.DataArray]
             Benchmark map.
-        positive_categories : Optional[Union[Number, Iterable[Number]]]
+        positive_categories: Union[Number, Iterable[Number], Dict[str, Union[Number, Iterable[Number]]]], default = None
             Number or list of numbers representing the values to consider as the positive condition. When the average argument is either "macro" or "weighted", this represents the categories to compute metrics for.
         comparison_function : Union[Callable, nb.np.ufunc.dufunc.DUFunc, np.ufunc, np.vectorize, str], default = 'szudzik'
             Comparison function. Created by decorating function with @nb.vectorize() or using np.ufunc(). Use of numba is preferred as it is faster. Strings with registered comparison_functions are also accepted. Possible options include "pairing_dict". If passing "pairing_dict" value, please see the description for the argument for more information on behaviour.
@@ -191,7 +195,7 @@ class GVALXarray:
             Encoded no data value to write to agreement map output. A nodata argument must be passed. This will use `rxr.rio.write_nodata(nodata, encode=encode_nodata)`.
         exclude_value : Optional[Number], default = None
             Value to exclude from crosstab. This could be used to denote a no data value if masking wasn't used. By default, NaNs are not cross-tabulated.
-        negative_categories : Optional[Union[Number, Iterable[Number]]], default = None
+        negative_categories: Union[Number, Iterable[Number], Dict[str, Union[Number, Iterable[Number]]]], default=None
             Number or list of numbers representing the values to consider as the negative condition. This should be set to None when no negative categories are used or when the average type is "macro" or "weighted".
         average : str, default = "micro"
             Type of average to use when computing metrics. Options are "micro", "macro", and "weighted".

--- a/src/gval/comparison/compute_categorical_metrics.py
+++ b/src/gval/comparison/compute_categorical_metrics.py
@@ -29,6 +29,12 @@ def _create_set_dict(categories):
     """Creates set valued dictionary"""
     if not isinstance(categories, dict):
         categories = {"candidate": categories, "benchmark": categories}
+    else:
+        if "candidate" not in categories or "benchmark" not in categories:
+            raise ValueError(
+                "Make sure both candidate and benchmark entries are in the dictionary passed"
+                "in to negative_categories, positive_categories, or both."
+            )
 
     categories["candidate"] = _convert_to_set(categories["candidate"])
     categories["benchmark"] = _convert_to_set(categories["benchmark"])

--- a/src/gval/comparison/compute_continuous_metrics.py
+++ b/src/gval/comparison/compute_continuous_metrics.py
@@ -8,7 +8,7 @@ __author__ = "Fernando Aristizabal"
 from typing import Iterable, Union, List
 
 import numpy as np
-import pandera as pa
+import pandera.pandas as pa
 import pandas as pd
 from pandera.typing import DataFrame
 import xarray as xr

--- a/src/gval/comparison/compute_probabilistic_metrics.py
+++ b/src/gval/comparison/compute_probabilistic_metrics.py
@@ -8,7 +8,7 @@ from typing import Optional, Any, Union
 
 import numpy as np
 import pandas as pd
-import pandera as pa
+import pandera.pandas as pa
 from pandera.typing import DataFrame
 import xskillscore as xs
 import xarray as xr

--- a/src/gval/comparison/tabulation.py
+++ b/src/gval/comparison/tabulation.py
@@ -19,7 +19,7 @@ from numbers import Number
 import numpy as np
 import pandas as pd
 import xarray as xr
-import pandera as pa
+import pandera.pandas as pa
 from pandera.typing import DataFrame
 import dask
 from flox.xarray import xarray_reduce

--- a/src/gval/utils/schemas.py
+++ b/src/gval/utils/schemas.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Union
 __author__ = "Fernando Aristizabal"
 
 import pandas as pd
-import pandera as pa
+import pandera.pandas as pa
 from pandera.typing import Series, Index, Int64
 from shapely import Geometry
 

--- a/tests/cases_catalogs.py
+++ b/tests/cases_catalogs.py
@@ -155,7 +155,7 @@ on = ["compare_id"] * 4
 map_ids = ["map_id", ("map_id", "map_id"), "map_id", "map_id"]
 how = ["inner"] * 4
 compare_type = ["continuous"] * 2 + ["categorical"] * 2
-dask = [False, True] * 2
+dask = [False, False] * 2
 
 compare_kwargs = [
     {

--- a/tests/cases_compute_categorical_metrics.py
+++ b/tests/cases_compute_categorical_metrics.py
@@ -133,6 +133,56 @@ expected_dfs = [
             "true_positive_rate": {0: 0.692265, 1: 0.567729},
         }
     ),
+    pd.DataFrame(
+        {
+            "band": {0: "1", 1: "2"},
+            "fn": {0: 1098.0, 1: 3689.0},
+            "fp": {0: 5444.0, 1: 2470.0},
+            "tn": {0: 9489.0, 1: 5200.0},
+            "tp": {0: 2470.0, 1: 4845.0},
+            "accuracy": {0: 0.646397492027458, 1: 0.6199086645272772},
+            "balanced_accuracy": {0: 0.6638514325121567, 1: 0.6228475926801269},
+            "critical_success_index": {
+                0: 0.2740790057700843,
+                1: 0.44029443838604143,
+            },
+            "equitable_threat_score": {0: 0.12607286705706663, 1: 0.1387798441467566},
+            "f_score": {0: 0.43023863438425364, 1: 0.6113950406965739},
+            "false_discovery_rate": {0: 0.6878948698508971, 1: 0.33766233766233766},
+            "false_negative_rate": {0: 0.3077354260089686, 1: 0.43227091633466136},
+            "false_omission_rate": {0: 0.10371209974497024, 1: 0.4150073124085949},
+            "false_positive_rate": {0: 0.364561708966718, 1: 0.3220338983050847},
+            "fowlkes_mallows_index": {
+                0: 0.46482182066151334,
+                1: 0.6132115084666983,
+            },
+            "matthews_correlation_coefficient": {
+                0: 0.2613254543945788,
+                1: 0.2465114118474816,
+            },
+            "negative_likelihood_ratio": {
+                0: 0.4842884515325037,
+                1: 0.6375996015936255,
+            },
+            "negative_predictive_value": {
+                0: 0.8962879002550298,
+                1: 0.5849926875914051,
+            },
+            "overall_bias": {0: 2.2180493273542603, 1: 0.8571595969064917},
+            "positive_likelihood_ratio": {
+                0: 1.898895459847184,
+                1: 1.762948207171315,
+            },
+            "positive_predictive_value": {
+                0: 0.31210513014910285,
+                1: 0.6623376623376623,
+            },
+            "prevalence": {0: 0.1928544403005243, 1: 0.5266600839298938},
+            "prevalence_threshold": {0: 0.4205207112769604, 1: 0.42959744253992793},
+            "true_negative_rate": {0: 0.635438291033282, 1: 0.6779661016949152},
+            "true_positive_rate": {0: 0.6922645739910314, 1: 0.5677290836653387},
+        }
+    ),
 ]
 
 input_dfs = [
@@ -288,6 +338,32 @@ input_dfs = [
             },
         }
     ),
+    pd.DataFrame(
+        {
+            "band": {
+                0: "1",
+                1: "1",
+                2: "1",
+                3: "1",
+                4: "2",
+                5: "2",
+                6: "2",
+                7: "2",
+            },
+            "candidate_values": {0: 1, 1: 1, 2: 2, 3: 2, 4: 1, 5: 1, 6: 2, 7: 2},
+            "benchmark_values": {0: 4, 1: 3, 2: 4, 3: 3, 4: 4, 5: 3, 6: 4, 7: 3},
+            "counts": {
+                0: 9489,
+                1: 1098,
+                2: 5444,
+                3: 2470,
+                4: 5200,
+                5: 3689,
+                6: 2470,
+                7: 4845,
+            },
+        }
+    ),
 ]
 
 metrics_input = [
@@ -296,9 +372,10 @@ metrics_input = [
     "accuracy",
     ["accuracy", "critical_success_index", "f_score"],
     "all",
+    "all",
 ]
-positive_categories_input = [(1, 3), 2, 2, 2, 2]
-negative_categories_input = [2, 1, 1, 1, None]
+positive_categories_input = [(1, 3), 2, 2, 2, 2, {"candidate": [2], "benchmark": [3]}]
+negative_categories_input = [2, 1, 1, 1, None, {"candidate": [1], "benchmark": [4]}]
 
 
 @parametrize(
@@ -368,11 +445,11 @@ input_dfs = [
             },
         }
     )
-] * 3
+] * 4
 
-negative_categories_input = [None, 4, (2, 3)]
-positive_categories_input = [4, 3, (1, 2)]
-exceptions = [ValueError, ValueError, ValueError]
+negative_categories_input = [None, 4, (2, 3), {"candidate": [1], "benchmark_fail": [2]}]
+positive_categories_input = [4, 3, (1, 2), {"candidate": [2], "arbitrary_fail": [5]}]
+exceptions = [ValueError, ValueError, ValueError, ValueError]
 
 
 @parametrize(


### PR DESCRIPTION
This PR addresses issue #69.  While the previous assignment of positive and negative categories are usable you may now pass in dictionaries that describe what classes are positive and negative for both the candidate and benchmark dataset.

## Changes

- requirements.txt:  Added dask[dataframe] dependency
- src/gva/accessors/gval_dataframe.py:  Added dictionary type arguments for positive and negative categories
- src/gval/accessors/gval_xarray.py:  Added dictionary type arguments for positive and negative categories
- src/gva/comparison/compute_categorical_metrics.py:  Convert positive and negative categories to set dictionaries to unobtrusively allow different positive and negative categories for the candidate and benchmark dataset.
- src/gval/comparison/computes_continuous_metrics.py: Change pandera import addressing deprecation warning.
- src/gval/comparison/computes_probabilistic_metrics.py : Change pandera import addressing deprecation warning.
- src/gval/comparison/tabulation.py:  Change pandera import addressing deprecation warning.
- src/gval/utils/schema.py:  Change pandera import addressing deprecation warning.
- tests/cases_compute_categorical_metrics.py: Add pass fail tests for different positive/negative values in candidate and benchmark crosstab dataframe.


## Checklist

- [x] PR has an informative and human-readable title and description.
- [x] Changes are limited to a single goal (no scope creep).
- [x] Code can be automatically merged (no conflicts).
- [x] Code follows project standards documented on the [Contributing page](https://github.com/NOAA-OWP/gval/blob/main/docs/markdown/05_CONTRIBUTING.MD).
- [x] Passes all existing automated sessions using `nox`. This includes linting, testing, and doc building.
    - [x] Test coverage is at 95% or above.
- [x] Placeholder code is flagged (`# PLACEHOLDER:`) and future TODOs are captured in comments (`# TODO:`).
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
