### PR TITLE
Fix warning for deprecated use of gropuby then apply.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 requires-python = ">=3.10"
 keywords = ["geospatial", "evaluations"]
 license = {text = "MIT"}
-version = "0.2.12"
+version = "0.2.13"
 dynamic = ["readme", "dependencies"]
 
 [project.optional-dependencies]

--- a/src/gval/comparison/compute_categorical_metrics.py
+++ b/src/gval/comparison/compute_categorical_metrics.py
@@ -289,7 +289,7 @@ def _compute_categorical_metrics(
         # groupby sample identifiers then compute metrics
         metric_df = (
             crosstab_df.groupby(groupby_cols)
-            .apply(compute_metrics_per_sample)
+            .apply(compute_metrics_per_sample, include_groups=False)
             .reset_index()
         )
 


### PR DESCRIPTION
This quick fix adds `include_groups=False` to the apply function of a groupby pandas DataFrame in order to stop the deprecated use warning.

## Changes

- compute_categorical_metrics.py: Added the include_groups argument
- pyproject.toml: Increment the patch version

## Testing

1.  All unit tests pass for python 3.10, 3.11, 3.12, and 3.13

- [x] PR has an informative and human-readable title and description.
- [x] Changes are limited to a single goal (no scope creep).
- [x] Code can be automatically merged (no conflicts).
- [x] Code follows project standards documented on the [Contributing page](https://github.com/NOAA-OWP/gval/blob/main/docs/markdown/05_CONTRIBUTING.MD).
- [x] Passes all existing automated sessions using `nox`. This includes linting, testing, and doc building.
    - [x] Test coverage is at 95% or above.
- [x] Placeholder code is flagged (`# PLACEHOLDER:`) and future TODOs are captured in comments (`# TODO:`).
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
